### PR TITLE
enable configuring of transaction_pool capacity.

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -30,6 +30,8 @@ heartbeat = "tcp://*:9092"
 # New certs can be added without needing to restart the server.
 #client-allowed-certs = "client-certs/"
 
+# Transaction pool capacity- limit for number of transactions.
+#txpool_capacity = 2000
 # Uncomment to give this worker a named UUID. Must be unique.
 #name = "ada"
 # Number of outgoing network connections to p2p network.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -127,6 +127,7 @@ void load_config(config_type& config, boost::filesystem::path& config_path)
     root.lookupValue("certificate", config.certificate);
     root.lookupValue("client-allowed-certs", config.client_allowed_certs);
     load_whitelist(root, config);
+    root.lookupValue("txpool_capacity", config.txpool_capacity);
     root.lookupValue("name", config.name);
     root.lookupValue("outgoing-connections", config.outgoing_connections);
     root.lookupValue("listener_enabled", config.listener_enabled);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -51,6 +51,7 @@ struct config_type
     std::string certificate = "";
     ipaddress_list whitelist;
     std::string client_allowed_certs = "ALLOW_ALL_CERTS";
+    unsigned int txpool_capacity = 2000;
     std::string name;
     unsigned int outgoing_connections = 8;
     bool listener_enabled = true;

--- a/src/node_impl.cpp
+++ b/src/node_impl.cpp
@@ -123,6 +123,7 @@ bool node_impl::start(config_type& config)
     chain_.subscribe_reorganize(
         std::bind(&node_impl::reorganize, this, _1, _2, _3, _4));
     // Start transaction pool
+    txpool_.set_capacity(config.txpool_capacity);
     txpool_.start();
     // Outgoing connections setting in config file before we
     // start p2p network subsystem.


### PR DESCRIPTION
By default this value has 2000. Once the limit is reached, old transactions are removed. Allow configuration of this value.