### PR TITLE
Make narrowing casts explicit and guarded.

### DIFF
--- a/builds/msvc/vs2013/bitcoin-server/bitcoin-server.props
+++ b/builds/msvc/vs2013/bitcoin-server/bitcoin-server.props
@@ -12,8 +12,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)include\;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <!-- Suppressing 4267 is hazardous, should eventually remove this. -->
-      <DisableSpecificWarnings>4267;4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4290;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <EnablePREfast>false</EnablePREfast>
       <PreprocessorDefinitions>_WIN32_WINNT=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(DebugOrRelease)' == 'Release'">BITCOIN_DISABLE_ASSERTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/service/blockchain.cpp
+++ b/src/service/blockchain.cpp
@@ -75,10 +75,13 @@ void blockchain_fetch_last_height(node_impl& node,
 void last_height_fetched(const std::error_code& ec, size_t last_height,
     const incoming_message& request, queue_send_callback queue_send)
 {
+    BITCOIN_ASSERT(last_height <= bc::max_uint32);
+    auto last_height32 = static_cast<uint32_t>(last_height);
+
     data_chunk result(8);
     auto serial = make_serializer(result.begin());
     write_error_code(serial, ec);
-    serial.write_4_bytes(last_height);
+    serial.write_4_bytes(last_height32);
     BITCOIN_ASSERT(serial.iterator() == result.end());
     log_debug(LOG_REQUEST)
         << "blockchain.fetch_last_height() finished. Sending response.";
@@ -231,13 +234,18 @@ void transaction_index_fetched(const std::error_code& ec,
     size_t block_height, size_t index,
     const incoming_message& request, queue_send_callback queue_send)
 {
+    BITCOIN_ASSERT(index <= max_uint32);
+    auto index32 = static_cast<uint32_t>(index);
+    BITCOIN_ASSERT(block_height <= max_uint32);
+    auto block_height32 = static_cast<uint32_t>(block_height);
+
     // error_code (4), block_height (4), index (4)
     data_chunk result(12);
     auto serial = make_serializer(result.begin());
     write_error_code(serial, ec);
     BITCOIN_ASSERT(serial.iterator() == result.begin() + 4);
-    serial.write_4_bytes(block_height);
-    serial.write_4_bytes(index);
+    serial.write_4_bytes(block_height32);
+    serial.write_4_bytes(index32);
     log_debug(LOG_REQUEST)
         << "blockchain.fetch_transaction_index() finished. Sending response.";
     outgoing_message response(request, result);
@@ -299,12 +307,15 @@ void blockchain_fetch_block_height(node_impl& node,
 void block_height_fetched(const std::error_code& ec, size_t block_height,
     const incoming_message& request, queue_send_callback queue_send)
 {
+    BITCOIN_ASSERT(block_height <= max_uint32);
+    auto block_height32 = static_cast<uint32_t>(block_height);
+
     // error_code (4), height (4)
     data_chunk result(8);
     auto serial = make_serializer(result.begin());
     write_error_code(serial, ec);
     BITCOIN_ASSERT(serial.iterator() == result.begin() + 4);
-    serial.write_4_bytes(block_height);
+    serial.write_4_bytes(block_height32);
     log_debug(LOG_REQUEST)
         << "blockchain.fetch_block_height() finished. Sending response.";
     outgoing_message response(request, result);

--- a/src/service/compat.cpp
+++ b/src/service/compat.cpp
@@ -123,17 +123,23 @@ void COMPAT_send_history_result(
     BITCOIN_ASSERT(serial.iterator() == result.begin() + 4);
     for (const row_pair& pair: pairs)
     {
+        BITCOIN_ASSERT(pair.output->height <= max_uint32);
+        auto output_height32 = static_cast<uint32_t>(pair.output->height);
+
         DEBUG_ONLY(auto start_pos = serial.iterator());
         BITCOIN_ASSERT(pair.output != nullptr);
         serial.write_hash(pair.output->point.hash);
         serial.write_4_bytes(pair.output->point.index);
-        serial.write_4_bytes(pair.output->height);
+        serial.write_4_bytes(output_height32);
         serial.write_8_bytes(pair.output->value);
         if (pair.spend)
         {
+            BITCOIN_ASSERT(pair.spend->height <= max_uint32);
+            auto spend_height32 = static_cast<uint32_t>(pair.spend->height);
+
             serial.write_hash(pair.spend->point.hash);
             serial.write_4_bytes(pair.spend->point.index);
-            serial.write_4_bytes(pair.spend->height);
+            serial.write_4_bytes(spend_height32);
         }
         else
         {

--- a/src/service/fetch_x.cpp
+++ b/src/service/fetch_x.cpp
@@ -57,13 +57,16 @@ void send_history_result(
     write_error_code(serial, ec);
     for (const history_row& row: history)
     {
+        BITCOIN_ASSERT(row.height <= max_uint32);
+        auto row_height32 = static_cast<uint32_t>(row.height);
+
         if (row.id == point_ident::output)
             serial.write_byte(0);
         else // if (row.id == point_ident::spend)
             serial.write_byte(1);
         serial.write_hash(row.point.hash);
         serial.write_4_bytes(row.point.index);
-        serial.write_4_bytes(row.height);
+        serial.write_4_bytes(row_height32);
         serial.write_8_bytes(row.value);
     }
     BITCOIN_ASSERT(serial.iterator() == result.end());

--- a/src/service/protocol.cpp
+++ b/src/service/protocol.cpp
@@ -58,10 +58,14 @@ void protocol_broadcast_transaction(node_impl& node,
 void protocol_total_connections(node_impl& node,
     const incoming_message& request, queue_send_callback queue_send)
 {
+    BITCOIN_ASSERT(node.protocol().total_connections() <= max_uint32);
+    auto total_connections32 = static_cast<uint32_t>(
+        node.protocol().total_connections());
+
     data_chunk result(8);
     auto serial = make_serializer(result.begin());
     write_error_code(serial, std::error_code());
-    serial.write_4_bytes(node.protocol().total_connections());
+    serial.write_4_bytes(total_connections32);
     BITCOIN_ASSERT(serial.iterator() == result.end());
     log_debug(LOG_REQUEST)
         << "protocol.total_connections() finished. Sending response.";

--- a/src/service/transaction_pool.cpp
+++ b/src/service/transaction_pool.cpp
@@ -58,8 +58,13 @@ void transaction_validated(
     auto serial = make_serializer(result.begin());
     write_error_code(serial, ec);
     BITCOIN_ASSERT(serial.iterator() == result.begin() + 4);
-    for (uint32_t unconfirm_index: unconfirmed)
-        serial.write_4_bytes(unconfirm_index);
+    for (auto unconfirmed_index: unconfirmed)
+    {
+        BITCOIN_ASSERT(unconfirmed_index <= max_uint32);
+        auto unconfirmed_index32 = static_cast<uint32_t>(unconfirmed_index);
+
+        serial.write_4_bytes(unconfirmed_index32);
+    }
     BITCOIN_ASSERT(serial.iterator() == result.end());
     log_debug(LOG_REQUEST)
         << "transaction_pool.validate() finished. Sending response: "

--- a/src/subscribe_manager.cpp
+++ b/src/subscribe_manager.cpp
@@ -209,6 +209,9 @@ void subscribe_manager::post_updates(const payment_address& address,
     size_t height, const hash_digest& block_hash,
     const transaction_type& tx)
 {
+    BITCOIN_ASSERT(height <= max_uint32);
+    auto height32 = static_cast<uint32_t>(height);
+
     // [ addr,version ] (1 byte)
     // [ addr.hash ] (20 bytes)
     // [ height ] (4 bytes)
@@ -219,7 +222,7 @@ void subscribe_manager::post_updates(const payment_address& address,
     auto serial = make_serializer(data.begin());
     serial.write_byte(address.version());
     serial.write_short_hash(address.hash());
-    serial.write_4_bytes(height);
+    serial.write_4_bytes(height32);
     serial.write_hash(block_hash);
     BITCOIN_ASSERT(serial.iterator() == data.begin() + info_size);
     // Now write the tx part.
@@ -244,6 +247,9 @@ void subscribe_manager::post_stealth_updates(const binary_type& prefix,
     size_t height, const hash_digest& block_hash,
     const transaction_type& tx)
 {
+    BITCOIN_ASSERT(height <= max_uint32);
+    auto height32 = static_cast<uint32_t>(height);
+
     // [ bitfield ] (4 bytes)
     // [ height ] (4 bytes)
     // [ block_hash ] (32 bytes)
@@ -252,7 +258,7 @@ void subscribe_manager::post_stealth_updates(const binary_type& prefix,
     data_chunk data(info_size + satoshi_raw_size(tx));
     auto serial = make_serializer(data.begin());
     serial.write_data(prefix.blocks());
-    serial.write_4_bytes(height);
+    serial.write_4_bytes(height32);
     serial.write_hash(block_hash);
     BITCOIN_ASSERT(serial.iterator() == data.begin() + info_size);
     // Now write the tx part.


### PR DESCRIPTION
This is the last of the fixes to narrowing casts across the entire libbitcoin stack. All builds are now clean as 32 bit and 64 bit.