### PR TITLE
Protocol scheme used :\\ instead of ://.

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -118,7 +118,7 @@ std::istream& operator>>(std::istream& input, endpoint_type& argument)
 std::ostream& operator<<(std::ostream& output, const endpoint_type& argument)
 {
     if (!argument.scheme_.empty())
-        output << argument.scheme_ << ":\\";
+        output << argument.scheme_ << "://";
 
     output << argument.host_;
 


### PR DESCRIPTION
This prevented the server from binding to both service and publisher ports.

Closes #45 and #46.