### PR TITLE
Dynamic min threadpool config, stub in address worker.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ src_libbitcoin_server_la_SOURCES = \
     src/services/transaction_service.cpp \
     src/utility/authenticator.cpp \
     src/utility/fetch_helpers.cpp \
+    src/utility/notifications.cpp \
     src/workers/address_worker.cpp \
     src/workers/query_worker.cpp
 
@@ -121,7 +122,8 @@ include_bitcoin_server_services_HEADERS = \
 include_bitcoin_server_utilitydir = ${includedir}/bitcoin/server/utility
 include_bitcoin_server_utility_HEADERS = \
     include/bitcoin/server/utility/authenticator.hpp \
-    include/bitcoin/server/utility/fetch_helpers.hpp
+    include/bitcoin/server/utility/fetch_helpers.hpp \
+    include/bitcoin/server/utility/notifications.hpp
 
 include_bitcoin_server_workersdir = ${includedir}/bitcoin/server/workers
 include_bitcoin_server_workers_HEADERS = \

--- a/builds/msvc/vs2013/libbitcoin-server/libbitcoin-server.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-server/libbitcoin-server.vcxproj
@@ -89,6 +89,7 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\server\settings.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\server\utility\authenticator.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\server\utility\fetch_helpers.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\server\utility\notifications.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\server\version.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\server\workers\address_worker.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\server\workers\query_worker.hpp" />
@@ -111,6 +112,7 @@
     <ClCompile Include="..\..\..\..\src\settings.cpp" />
     <ClCompile Include="..\..\..\..\src\utility\authenticator.cpp" />
     <ClCompile Include="..\..\..\..\src\utility\fetch_helpers.cpp" />
+    <ClCompile Include="..\..\..\..\src\utility\notifications.cpp" />
     <ClCompile Include="..\..\..\..\src\workers\address_worker.cpp" />
     <ClCompile Include="..\..\..\..\src\workers\query_worker.cpp" />
   </ItemGroup>

--- a/builds/msvc/vs2013/libbitcoin-server/libbitcoin-server.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-server/libbitcoin-server.vcxproj.filters
@@ -112,6 +112,9 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\server\utility\fetch_helpers.hpp">
       <Filter>include\bitcoin\server\utility</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\server\utility\notifications.hpp">
+      <Filter>include\bitcoin\server\utility</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\server_node.cpp">
@@ -167,6 +170,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\services\heartbeat_service.cpp">
       <Filter>src\services</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\utility\notifications.cpp">
+      <Filter>src\utility</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/console/executor.hpp
+++ b/console/executor.hpp
@@ -55,6 +55,7 @@ private:
 
     void initialize_output();
     bool verify_directory();
+    void set_minimum_threadpool_size();
     bool run();
 
     // Termination state.

--- a/data/bs.cfg
+++ b/data/bs.cfg
@@ -1,7 +1,7 @@
 # Libbitcoin Server configuration file
 
 [network]
-# The number of threads in the application threadpool, defaults to 50.
+# The minimum number of threads in the application threadpool, defaults to 50.
 threads = 50
 # The magic number for message headers, defaults to 3652501241 (use 118034699 for testnet).
 identifier = 3652501241

--- a/include/bitcoin/server.hpp
+++ b/include/bitcoin/server.hpp
@@ -34,6 +34,7 @@
 #include <bitcoin/server/services/transaction_service.hpp>
 #include <bitcoin/server/utility/authenticator.hpp>
 #include <bitcoin/server/utility/fetch_helpers.hpp>
+#include <bitcoin/server/utility/notifications.hpp>
 #include <bitcoin/server/workers/address_worker.hpp>
 #include <bitcoin/server/workers/query_worker.hpp>
 

--- a/include/bitcoin/server/server_node.hpp
+++ b/include/bitcoin/server/server_node.hpp
@@ -20,7 +20,6 @@
 #ifndef LIBBITCOIN_SERVER_SERVER_NODE_HPP
 #define LIBBITCOIN_SERVER_SERVER_NODE_HPP
 
-#include <future>
 #include <memory>
 #include <bitcoin/node.hpp>
 #include <bitcoin/protocol.hpp>
@@ -30,8 +29,9 @@
 #include <bitcoin/server/services/heartbeat_service.hpp>
 #include <bitcoin/server/services/query_service.hpp>
 #include <bitcoin/server/services/transaction_service.hpp>
-////#include <bitcoin/server/services/address_worker.hpp>
 #include <bitcoin/server/utility/authenticator.hpp>
+#include <bitcoin/server/utility/notifications.hpp>
+#include <bitcoin/server/workers/address_worker.hpp>
 
 namespace libbitcoin {
 namespace server {
@@ -50,6 +50,9 @@ public:
 
     // Properties.
     // ----------------------------------------------------------------------------
+
+    /// Address worker notification subscription.
+    virtual notifications& notifier();
 
     /// Server configuration settings.
     virtual const settings& server_settings() const;
@@ -88,6 +91,7 @@ private:
 
     // These are thread safe.
     authenticator authenticator_;
+    notifications notifications_;
     query_service secure_query_service_;
     query_service public_query_service_;
     heartbeat_service secure_heartbeat_service_;
@@ -96,6 +100,8 @@ private:
     block_service public_block_service_;
     transaction_service secure_transaction_service_;
     transaction_service public_transaction_service_;
+    address_worker secure_address_worker_;
+    address_worker public_address_worker_;
 };
 
 } // namespace server

--- a/include/bitcoin/server/server_node.hpp
+++ b/include/bitcoin/server/server_node.hpp
@@ -20,6 +20,7 @@
 #ifndef LIBBITCOIN_SERVER_SERVER_NODE_HPP
 #define LIBBITCOIN_SERVER_SERVER_NODE_HPP
 
+#include <cstdint>
 #include <memory>
 #include <bitcoin/node.hpp>
 #include <bitcoin/protocol.hpp>
@@ -41,6 +42,9 @@ class BCS_API server_node
 {
 public:
     typedef std::shared_ptr<server_node> ptr;
+
+    /// Compute the minimum threadpool size required to run the server.
+    static uint32_t threads_required(const configuration& configuration);
 
     /// Construct a server node.
     server_node(const configuration& configuration);
@@ -77,10 +81,11 @@ public:
     virtual bool close() override;
 
 private:
-    static configuration minimum_threads(const configuration& configuration);
 
     void handle_running(const code& ec, result_handler handler);
 
+    bool start_services();
+    bool start_authenticator();
     bool start_query_services();
     bool start_heartbeat_services();
     bool start_block_services();

--- a/include/bitcoin/server/services/block_service.hpp
+++ b/include/bitcoin/server/services/block_service.hpp
@@ -31,6 +31,7 @@ namespace server {
 
 class server_node;
 
+// This class is thread safe.
 // Subscribe to block acceptances into the long chain.
 class BCS_API block_service
   : public bc::protocol::zmq::worker
@@ -50,7 +51,7 @@ public:
     bool start() override;
 
     /// Stop the service.
-    bool stop();
+    bool stop() override;
 
 protected:
     typedef chain::block::ptr_list block_list;

--- a/include/bitcoin/server/services/heartbeat_service.hpp
+++ b/include/bitcoin/server/services/heartbeat_service.hpp
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SERVER_HEART_SERVICE_HPP
-#define LIBBITCOIN_SERVER_HEART_SERVICE_HPP
+#ifndef LIBBITCOIN_SERVER_HEARTBEAT_SERVICE_HPP
+#define LIBBITCOIN_SERVER_HEARTBEAT_SERVICE_HPP
 
 #include <cstdint>
 #include <memory>
@@ -31,6 +31,8 @@ namespace server {
 
 class server_node;
 
+// This class is thread safe.
+// Subscribe to a pulse from a dedicated service endpoint.
 class BCS_API heartbeat_service
   : public bc::protocol::zmq::worker
 {

--- a/include/bitcoin/server/services/query_service.hpp
+++ b/include/bitcoin/server/services/query_service.hpp
@@ -30,15 +30,19 @@ namespace server {
 
 class server_node;
 
+// This class is thread safe.
+// Submit queries and address subscriptions and receive address notifications.
 class BCS_API query_service
   : public bc::protocol::zmq::worker
 {
 public:
     typedef std::shared_ptr<query_service> ptr;
 
-    /// The fixed inprocess worker endpoints.
-    static const config::endpoint public_worker;
-    static const config::endpoint secure_worker;
+    /// The fixed inprocess query and notify worker endpoints.
+    static const config::endpoint public_query;
+    static const config::endpoint secure_query;
+    static const config::endpoint public_notify;
+    static const config::endpoint secure_notify;
 
     /// Construct a query service.
     query_service(bc::protocol::zmq::authenticator& authenticator,
@@ -47,8 +51,8 @@ public:
 protected:
     typedef bc::protocol::zmq::socket socket;
 
-    virtual bool bind(socket& router, socket& dealer);
-    virtual bool unbind(socket& router, socket& dealer);
+    virtual bool bind(socket& router, socket& dealer, socket& pair);
+    virtual bool unbind(socket& router, socket& dealer, socket& pair);
 
     // Implement the service.
     virtual void work();

--- a/include/bitcoin/server/services/transaction_service.hpp
+++ b/include/bitcoin/server/services/transaction_service.hpp
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SERVER_TRANS_SERVICE_HPP
-#define LIBBITCOIN_SERVER_TRANS_SERVICE_HPP
+#ifndef LIBBITCOIN_SERVER_TRANSACTION_SERVICE_HPP
+#define LIBBITCOIN_SERVER_TRANSACTION_SERVICE_HPP
 
 #include <memory>
 #include <bitcoin/protocol.hpp>
@@ -30,6 +30,7 @@ namespace server {
 
 class server_node;
 
+// This class is thread safe.
 // Subscribe to transaction acceptances into the transaction memory pool.
 class BCS_API transaction_service
   : public bc::protocol::zmq::worker
@@ -49,7 +50,7 @@ public:
     bool start() override;
 
     /// Stop the service.
-    bool stop();
+    bool stop() override;
 
 protected:
     typedef bc::protocol::zmq::socket socket;

--- a/include/bitcoin/server/utility/notifications.hpp
+++ b/include/bitcoin/server/utility/notifications.hpp
@@ -17,33 +17,23 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SERVER_ADDRESS_HPP
-#define LIBBITCOIN_SERVER_ADDRESS_HPP
+#ifndef LIBBITCOIN_SERVER_NOTIFICATIONS_HPP
+#define LIBBITCOIN_SERVER_NOTIFICATIONS_HPP
 
 #include <bitcoin/server/define.hpp>
 #include <bitcoin/server/messages/incoming.hpp>
 #include <bitcoin/server/messages/outgoing.hpp>
-#include <bitcoin/server/server_node.hpp>
 
 namespace libbitcoin {
 namespace server {
 
-/// Address interface.
-/// Class and method names are published and mapped to the zeromq interface.
-class BCS_API address
+/// Address notification subscription and renewal.
+class BCS_API notifications
 {
 public:
-    /// Fetch the blockchain and transaction pool history of a payment address.
-    static void fetch_history2(server_node& node,
-        const incoming& request, send_handler handler);
-
-    /// Subscribe to payment and stealth address notifications by prefix.
-    static void subscribe(server_node& node,
-        const incoming& request, send_handler handler);
-
-    /// Subscribe to payment and stealth address notifications by prefix.
-    static void renew(server_node& node,
-        const incoming& request, send_handler handler);
+    notifications();
+    virtual void subscribe(const incoming& request, send_handler handler);
+    virtual void renew(const incoming& request, send_handler handler);
 };
 
 } // namespace server

--- a/include/bitcoin/server/workers/query_worker.hpp
+++ b/include/bitcoin/server/workers/query_worker.hpp
@@ -29,13 +29,14 @@
 #include <bitcoin/server/messages/incoming.hpp>
 #include <bitcoin/server/messages/outgoing.hpp>
 #include <bitcoin/server/server_node.hpp>
-#include <bitcoin/server/workers/address_worker.hpp>
 
 namespace libbitcoin {
 namespace server {
 
 class server_node;
 
+// This class is thread safe.
+// Provide asynchronous query responses to the query service.
 class BCS_API query_worker
   : public bc::protocol::zmq::worker
 {
@@ -68,7 +69,6 @@ private:
 
     // These are thread safe.
     server_node& node_;
-    address_worker address_worker_;
     bc::protocol::zmq::authenticator& authenticator_;
 
     // This is protected by base class mutex.

--- a/src/interface/address.cpp
+++ b/src/interface/address.cpp
@@ -25,7 +25,6 @@
 #include <bitcoin/server/messages/outgoing.hpp>
 #include <bitcoin/server/server_node.hpp>
 #include <bitcoin/server/utility/fetch_helpers.hpp>
-#include <bitcoin/server/workers/address_worker.hpp>
 
 namespace libbitcoin {
 namespace server {
@@ -50,16 +49,16 @@ void address::fetch_history2(server_node& node, const incoming& request,
             _1, _2, request, handler));
 }
 
-void address::subscribe(address_worker& notifier, const incoming& request,
+void address::subscribe(server_node& node, const incoming& request,
     send_handler handler)
 {
-    notifier.subscribe(request, handler);
+    node.notifier().subscribe(request, handler);
 }
 
-void address::renew(address_worker& notifier, const incoming& request,
+void address::renew(server_node& node, const incoming& request,
     send_handler handler)
 {
-    notifier.renew(request, handler);
+    node.notifier().renew(request, handler);
 }
 
 } // namespace server

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -122,7 +122,7 @@ options_metadata parser::load_settings()
     (
         "network.threads",
         value<uint32_t>(&configured.network.threads),
-        "The number of threads in the application threadpool, defaults to 50."
+        "The minimum number of threads in the application threadpool, defaults to 50."
     )
     (
         "network.identifier",

--- a/src/server_node.cpp
+++ b/src/server_node.cpp
@@ -19,6 +19,7 @@
  */
 #include <bitcoin/server/server_node.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <bitcoin/node.hpp>
@@ -95,16 +96,7 @@ void server_node::handle_running(const code& ec, result_handler handler)
         return;
     }
 
-    // Start authenticated context.
-    if (!authenticator_.start())
-    {
-        handler(error::operation_failed);
-        return;
-    }
-
-    // Start services and workers.
-    if (!start_query_services() || !start_heartbeat_services() ||
-        !start_block_services() || !start_transaction_services())
+    if (!start_services())
     {
         handler(error::operation_failed);
         return;
@@ -133,25 +125,27 @@ bool server_node::close()
 // Services.
 // ----------------------------------------------------------------------------
 
-// The number of threads available in the thread pool must be sufficient
-// to allocate the workers. This will wait forever on thread availability.
-bool server_node::start_query_workers(bool secure)
+bool server_node::start_services()
 {
-    auto& server = *this;
+    return
+        start_authenticator() && start_query_services() &&
+        start_heartbeat_services() && start_block_services() &&
+        start_transaction_services();
+}
+
+bool server_node::start_authenticator()
+{
     const auto& settings = configuration_.server;
+    const auto heartbeat_interval = settings.heartbeat_interval_seconds;
 
-    for (auto count = 0; count < settings.query_workers; ++count)
-    {
-        auto worker = std::make_shared<query_worker>(authenticator_,
-            server, secure);
+    if ((!settings.server_private_key && settings.secure_only) ||
+        ((!settings.query_service_enabled || settings.query_workers == 0) &&
+        (!settings.heartbeat_service_enabled || heartbeat_interval == 0) &&
+        (!settings.block_service_enabled) &&
+        (!settings.transaction_service_enabled)))
+        return true;
 
-        if (!worker->start())
-            return false;
-
-        subscribe_stop([=](const code&) { worker->stop(); });
-    }
-
-    return true;
+    return authenticator_.start();
 }
 
 bool server_node::start_query_services()
@@ -229,6 +223,75 @@ bool server_node::start_transaction_services()
         return false;
 
     return true;
+}
+
+// Called from start_query_services.
+bool server_node::start_query_workers(bool secure)
+{
+    auto& server = *this;
+    const auto& settings = configuration_.server;
+
+    for (auto count = 0; count < settings.query_workers; ++count)
+    {
+        auto worker = std::make_shared<query_worker>(authenticator_,
+            server, secure);
+
+        if (!worker->start())
+            return false;
+
+        subscribe_stop([=](const code&) { worker->stop(); });
+    }
+
+    return true;
+}
+
+// static
+uint32_t server_node::threads_required(const configuration& configuration)
+{
+    const auto& settings = configuration.server;
+    const auto threads = configuration.network.threads;
+    const auto heartbeat_interval = settings.heartbeat_interval_seconds;
+
+    // The network/node requires a minimum of one thread.
+    uint32_t required = 1;
+
+    if (settings.query_service_enabled && settings.query_workers > 0)
+    {
+        if (settings.server_private_key)
+        {
+            ++required;
+            required += settings.query_workers;
+            required += (settings.subscription_limit > 0 ? 1 : 0);
+        }
+
+        if (!settings.secure_only)
+        {
+            ++required;
+            required += settings.query_workers;
+            required += (settings.subscription_limit > 0 ? 1 : 0);
+        }
+    }
+
+    if (settings.heartbeat_service_enabled && heartbeat_interval > 0)
+    {
+        required += (settings.server_private_key ? 1 : 0);
+        required += (settings.secure_only ? 0 : 1);
+    }
+
+    if (settings.block_service_enabled)
+    {
+        required += (settings.server_private_key ? 1 : 0);
+        required += (settings.secure_only ? 0 : 1);
+    }
+
+    if (settings.transaction_service_enabled)
+    {
+        required += (settings.server_private_key ? 1 : 0);
+        required += (settings.secure_only ? 0 : 1);
+    }
+
+    // If any services are enabled increment for the authenticator.
+    return required == 1 ? required : required + 1;
 }
 
 } // namespace server

--- a/src/services/block_service.cpp
+++ b/src/services/block_service.cpp
@@ -62,7 +62,6 @@ bool block_service::start()
     return zmq::worker::start();
 }
 
-
 // No unsubscribe so must be kept in scope until subscriber stop complete.
 bool block_service::stop()
 {

--- a/src/utility/notifications.cpp
+++ b/src/utility/notifications.cpp
@@ -17,36 +17,25 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SERVER_ADDRESS_HPP
-#define LIBBITCOIN_SERVER_ADDRESS_HPP
+#include <bitcoin/server/utility/notifications.hpp>
 
-#include <bitcoin/server/define.hpp>
 #include <bitcoin/server/messages/incoming.hpp>
 #include <bitcoin/server/messages/outgoing.hpp>
-#include <bitcoin/server/server_node.hpp>
 
 namespace libbitcoin {
 namespace server {
 
-/// Address interface.
-/// Class and method names are published and mapped to the zeromq interface.
-class BCS_API address
+notifications::notifications()
 {
-public:
-    /// Fetch the blockchain and transaction pool history of a payment address.
-    static void fetch_history2(server_node& node,
-        const incoming& request, send_handler handler);
+}
 
-    /// Subscribe to payment and stealth address notifications by prefix.
-    static void subscribe(server_node& node,
-        const incoming& request, send_handler handler);
+void notifications::subscribe(const incoming& request, send_handler handler)
+{
+}
 
-    /// Subscribe to payment and stealth address notifications by prefix.
-    static void renew(server_node& node,
-        const incoming& request, send_handler handler);
-};
+void notifications::renew(const incoming& request, send_handler handler)
+{
+}
 
 } // namespace server
 } // namespace libbitcoin
-
-#endif

--- a/src/workers/query_worker.cpp
+++ b/src/workers/query_worker.cpp
@@ -44,7 +44,6 @@ query_worker::query_worker(zmq::authenticator& authenticator,
     secure_(secure),
     settings_(node.server_settings()),
     node_(node),
-    address_worker_(node),
     authenticator_(authenticator)
 {
     // The same interface is attached to the secure and public interfaces.
@@ -81,8 +80,8 @@ void query_worker::work()
 bool query_worker::connect(zmq::socket& router)
 {
     const auto security = secure_ ? "secure" : "public";
-    const auto& endpoint = secure_ ? query_service::secure_worker :
-        query_service::public_worker;
+    const auto& endpoint = secure_ ? query_service::secure_query :
+        query_service::public_query;
 
     const auto ec = router.connect(endpoint);
 
@@ -175,10 +174,10 @@ void query_worker::query(zmq::socket& router)
 // ----------------------------------------------------------------------------
 
 // Class and method names must match protocol expectations (do not change).
-#define ATTACH(class_name, method_name, instance) \
+#define ATTACH(class_name, method_name, node) \
     attach(#class_name "." #method_name, \
         std::bind(&bc::server::class_name::method_name, \
-            std::ref(instance), _1, _2));
+            std::ref(node), _1, _2));
 
 void query_worker::attach(const std::string& command,
     command_handler handler)
@@ -213,8 +212,8 @@ void query_worker::attach_interface()
     ATTACH(address, fetch_history2, node_);
 
     // TODO: add renew to client.
-    ATTACH(address, renew, address_worker_);
-    ATTACH(address, subscribe, address_worker_);
+    ATTACH(address, renew, node_);
+    ATTACH(address, subscribe, node_);
 }
 
 #undef ATTACH


### PR DESCRIPTION
This computes the minimum number of threadpool threads during startup and uses the configured value as a floor. This therefore precludes the admin from having to know how many threads per service are defined in the implementation.

Also prevent startup of the authenticator (ZAP) service if there are no other services/workers. This saves a threadpool thread that would otherwise go to waste.

Also stub in the address worker (incomplete).