### PR TITLE
Be more explicit about needing to initialize blockchain

### DIFF
--- a/console/executor.hpp
+++ b/console/executor.hpp
@@ -74,7 +74,9 @@ private:
     "Runs a full bitcoin node in the global peer-to-peer network."
 
 #define BS_UNINITIALIZED_CHAIN \
-    "The %1% directory is not initialized."
+    "The %1% directory is not initialized. " \
+    "If this is your first time running bs, then please run:" \
+    " bs --initchain"
 #define BS_INITIALIZING_CHAIN \
     "Please wait while initializing %1% directory..."
 #define BS_INITCHAIN_NEW \

--- a/data/bs.cfg
+++ b/data/bs.cfg
@@ -58,8 +58,8 @@ seed = dnsseed.bitcoin.dashjr.org:8333
 history_start_height = 0
 # The lower limit of stealth indexing, defaults to 350000.
 stealth_start_height = 350000
-# The blockchain database directory, defaults to 'mainnet'.
-directory = mainnet
+# The blockchain database directory, defaults to 'mainnet-blockchain'.
+directory = mainnet-blockchain
 
 [blockchain]
 # The maximum number of orphan blocks in the pool, defaults to 50.


### PR DESCRIPTION
Extended the error message so it tells you to run --initchain, and also changed the default config name for the blockchain dbs from "mainnet" to "mainnet-blockchain".