### PR TITLE
Rem dead code, fix min threads/purge interval, simplify config, style.

### DIFF
--- a/data/bs.cfg
+++ b/data/bs.cfg
@@ -28,7 +28,7 @@ identifier = 3652501241
 # The port for incoming connections, defaults to 8333 (use 18333 for testnet).
 inbound_port = 8333
 # The target number of incoming network connections, defaults to 8.
-inbound_connections = 0
+inbound_connections = 8
 # The target number of outgoing network connections, defaults to 8.
 outbound_connections = 8
 # The attempt limit for manual connection establishment, defaults to 0 (forever).
@@ -145,22 +145,18 @@ initial_connections = 8
 transaction_pool_refresh = true
 
 [server]
-# The maximum number of query worker threads per endpoint, defaults to 1.
-query_workers = 1
-# The heartbeat interval, defaults to 5.
-heartbeat_interval_seconds = 5
-# The subscription expiration time, defaults to 10.
-subscription_expiration_minutes = 10
-# The maximum number of subscriptions, defaults to 100000000.
-subscription_limit = 100000000
 # Write service requests to the log, defaults to false.
 log_requests = false
 # Disable public endpoints, defaults to false.
 secure_only = false
-# Enable the query service, defaults to true.
-query_service_enabled = true
-# Enable the heartbeat service, defaults to false.
-heartbeat_service_enabled = false
+# The number of query worker threads per endpoint, defaults to 1.
+query_workers = 1
+# The maximum number of subscriptions, defaults to 100000000.
+subscription_limit = 100000000
+# The subscription expiration time, defaults to 10.
+subscription_expiration_minutes = 10
+# The heartbeat interval, zero disables service, defaults to 5.
+heartbeat_interval_seconds = 5
 # Enable the block publishing service, defaults to false.
 block_service_enabled = false
 # Enable the transaction publishing service, defaults to false.

--- a/include/bitcoin/server/settings.hpp
+++ b/include/bitcoin/server/settings.hpp
@@ -39,15 +39,13 @@ public:
     settings(bc::config::settings context);
 
     /// Properties.
-    uint16_t query_workers;
-    uint32_t heartbeat_interval_seconds;
-    uint32_t subscription_expiration_minutes;
-    uint32_t subscription_limit;
     bool log_requests;
     bool secure_only;
 
-    bool query_service_enabled;
-    bool heartbeat_service_enabled;
+    uint16_t query_workers;
+    uint32_t subscription_limit;
+    uint32_t subscription_expiration_minutes;
+    uint32_t heartbeat_interval_seconds;
     bool block_service_enabled;
     bool transaction_service_enabled;
 

--- a/include/bitcoin/server/workers/notification_worker.hpp
+++ b/include/bitcoin/server/workers/notification_worker.hpp
@@ -86,16 +86,15 @@ private:
     void purge();
     int32_t purge_interval_milliseconds() const;
 
-    bool handle_blockchain_reorganization(const code& ec, size_t fork_height,
+    bool handle_inventories(const code& ec, inventory_const_ptr packet);
+    bool handle_reorganization(const code& ec, size_t fork_height,
         block_const_ptr_list_const_ptr new_blocks,
         block_const_ptr_list_const_ptr old_blocks);
     bool handle_transaction_pool(const code& ec,
         const chain::point::indexes& indexes, transaction_const_ptr tx);
-    bool handle_inventory(const code& ec, inventory_const_ptr packet);
 
-    void notify_blocks(uint32_t fork_height,
-        block_const_ptr_list_const_ptr blocks);
-    void notify_block(socket& peer, uint32_t height, block_const_ptr block);
+    void notify_inventory(const bc::message::inventory_vector& inventory);
+    void notify_block(uint32_t height, block_const_ptr block);
     void notify_transaction(uint32_t height, const hash_digest& block_hash,
         const chain::transaction& tx);
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -389,26 +389,6 @@ options_metadata parser::load_settings()
 
     /* [server] */
     (
-        "server.query_workers",
-        value<uint16_t>(&configured.server.query_workers),
-        "The number of query worker threads per endpoint, defaults to 1."
-    )
-    (
-        "server.heartbeat_interval_seconds",
-        value<uint32_t>(&configured.server.heartbeat_interval_seconds),
-        "The heartbeat interval, defaults to 5."
-    )
-    (
-        "server.subscription_expiration_minutes",
-        value<uint32_t>(&configured.server.subscription_expiration_minutes),
-        "The subscription expiration time, defaults to 10."
-    )
-    (
-        "server.subscription_limit",
-        value<uint32_t>(&configured.server.subscription_limit),
-        "The maximum number of subscriptions, defaults to 100000000."
-    )
-    (
         "server.log_requests",
         value<bool>(&configured.server.log_requests),
         "Write service requests to the log, defaults to false."
@@ -419,14 +399,24 @@ options_metadata parser::load_settings()
         "Disable public endpoints, defaults to false."
     )
     (
-        "server.query_service_enabled",
-        value<bool>(&configured.server.query_service_enabled),
-        "Enable the query service, defaults to true."
+        "server.query_workers",
+        value<uint16_t>(&configured.server.query_workers),
+        "The number of query worker threads per endpoint, defaults to 1."
     )
     (
-        "server.heartbeat_service_enabled",
-        value<bool>(&configured.server.heartbeat_service_enabled),
-        "Enable the heartbeat service, defaults to false."
+        "server.subscription_limit",
+        value<uint32_t>(&configured.server.subscription_limit),
+        "The maximum number of subscriptions, defaults to 100000000."
+    )
+    (
+        "server.subscription_expiration_minutes",
+        value<uint32_t>(&configured.server.subscription_expiration_minutes),
+        "The subscription expiration time, defaults to 10."
+    )
+    (
+        "server.heartbeat_interval_seconds",
+        value<uint32_t>(&configured.server.heartbeat_interval_seconds),
+        "The heartbeat interval, zero disables service, defaults to 5."
     )
     (
         "server.block_service_enabled",

--- a/src/services/block_service.cpp
+++ b/src/services/block_service.cpp
@@ -161,10 +161,7 @@ bool block_service::handle_reorganization(const code& ec, size_t fork_height,
     }
 
     // Blockchain height is 64 bit but obelisk protocol is 32 bit.
-    BITCOIN_ASSERT(fork_height <= max_uint32);
-    const auto fork_height32 = static_cast<uint32_t>(fork_height);
-
-    publish_blocks(fork_height32, new_blocks);
+    publish_blocks(safe_unsigned<uint32_t>(fork_height), new_blocks);
     return true;
 }
 
@@ -188,9 +185,10 @@ void block_service::publish_blocks(uint32_t fork_height,
 
     if (ec)
     {
-        LOG_WARNING(LOG_SERVER)
-            << "Failed to connect " << security << " block worker: "
-            << ec.message();
+        // TODO: fix socket so that it can detect context stopped.
+        ////LOG_WARNING(LOG_SERVER)
+        ////    << "Failed to connect " << security << " block worker: "
+        ////    << ec.message();
         return;
     }
 

--- a/src/services/heartbeat_service.cpp
+++ b/src/services/heartbeat_service.cpp
@@ -33,7 +33,7 @@ static const auto domain = "heartbeat";
 using namespace bc::config;
 using namespace bc::protocol;
 
-static uint32_t to_milliseconds(uint16_t seconds)
+static inline uint32_t to_milliseconds(uint16_t seconds)
 {
     const auto milliseconds = static_cast<uint32_t>(seconds) * 1000;
     return std::min(milliseconds, max_uint32);

--- a/src/services/transaction_service.cpp
+++ b/src/services/transaction_service.cpp
@@ -184,9 +184,10 @@ void transaction_service::publish_transaction(transaction_const_ptr tx)
 
     if (ec)
     {
-        LOG_WARNING(LOG_SERVER)
-            << "Failed to connect " << security << " transaction worker: "
-            << ec.message();
+        // TODO: fix socket so that it can detect context stopped.
+        ////LOG_WARNING(LOG_SERVER)
+        ////    << "Failed to connect " << security << " transaction worker: "
+        ////    << ec.message();
         return;
     }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -33,8 +33,6 @@ settings::settings()
     subscription_limit(100000000),
     log_requests(false),
     secure_only(false),
-    query_service_enabled(true),
-    heartbeat_service_enabled(false),
     block_service_enabled(false),
     transaction_service_enabled(false),
     public_query_endpoint("tcp://*:9091"),

--- a/src/workers/query_worker.cpp
+++ b/src/workers/query_worker.cpp
@@ -91,7 +91,7 @@ bool query_worker::connect(zmq::socket& router)
         return false;
     }
 
-    LOG_DEBUG(LOG_SERVER)
+    LOG_INFO(LOG_SERVER)
         << "Connected " << security << " query worker to " << endpoint;
     return true;
 }


### PR DESCRIPTION
The dead code was not actually dead, it was incorrectly preserved from cut/paste from similar code and resulted in zeromq shutdown failures and warnings due to context inconsistency.