### PR TITLE
Regtestnet chain initialization  

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -127,7 +127,10 @@ bool executor::do_initchain()
 
         // Unfortunately we are limited to a choice of hardcoded chains.
         auto testnet = (metadata_.configured.network.identifier == 118034699u);
-        const auto genesis = testnet ? block::genesis_testnet() :
+        auto regtest = (metadata_.configured.network.identifier == 3669344250u);
+        const auto genesis =
+            regtest ? block::genesis_regtestnet() :
+            testnet ? block::genesis_testnet() :
             block::genesis_mainnet();
 
         const auto& settings = metadata_.configured.database;


### PR DESCRIPTION
This PR builds on https://github.com/libbitcoin/libbitcoin/pull/838 and allows the regtest chain to be initialized. 

If the configured network identifier is set to `3669344250`, then the regtestnet chain will be initialized on `bs --initchain`. While you _can_ initialize a regtestnet chain with the standard build, you must build the libbitcoin base library with the `WITH_REGTEST` flag defined, or else you will get proof or work errors and rejected blocks. 