### PR TITLE
Update Install.sh: Fix ZMQ version & set libbitcoin version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@
 #
 # Script options:
 # --build-boost            Builds Boost libraries.
+# --build-zmq              Builds ZeroMQ libraries.
 # --build-dir=<path>       Location of downloaded and intermediate files.
 # --prefix=<absolute-path> Library install location (defaults to /usr/local).
 # --disable-shared         Disables shared library builds.
@@ -35,6 +36,9 @@ BUILD_DIR="build-libbitcoin-server"
 BOOST_URL="http://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.tar.bz2"
 BOOST_ARCHIVE="boost_1_57_0.tar.bz2"
 
+# ZMQ version.
+#------------------------------------------------------------------------------
+ZMQ_VERSION="v4.2.3"
 
 # Define utility functions.
 #==============================================================================
@@ -213,6 +217,7 @@ for OPTION in "$@"; do
         (--build-png)      BUILD_PNG="yes";;
         (--build-qrencode) BUILD_QRENCODE="yes";;
         (--build-boost)    BUILD_BOOST="yes";;
+        (--build-zmq)      BUILD_ZMQ="yes";;
         (--build-dir=*)    BUILD_DIR="${OPTION#*=}";;
 
         # Standard build options.
@@ -292,6 +297,7 @@ display_message "BUILD_ZLIB            : $BUILD_ZLIB"
 display_message "BUILD_PNG             : $BUILD_PNG"
 display_message "BUILD_QRENCODE        : $BUILD_QRENCODE"
 display_message "BUILD_BOOST           : $BUILD_BOOST"
+display_message "BUILD_ZMQ             : $BUILD_ZMQ"
 display_message "PREFIX                : $PREFIX"
 display_message "BUILD_DIR             : $BUILD_DIR"
 display_message "DISABLE_SHARED        : $DISABLE_SHARED"
@@ -727,7 +733,9 @@ build_from_travis()
 build_all()
 {
     build_from_tarball_boost $BOOST_URL $BOOST_ARCHIVE bzip2 . $PARALLEL "$BUILD_BOOST" "${BOOST_OPTIONS[@]}"
-    build_from_github zeromq libzmq master $PARALLEL ${ZMQ_OPTIONS[@]} "$@"
+    if [[ ($BUILD_ZMQ) ]]; then
+        build_from_github zeromq libzmq $ZMQ_VERSION $PARALLEL ${ZMQ_OPTIONS[@]} "$@"
+    fi
     build_from_github libbitcoin secp256k1 version4 $PARALLEL ${SECP256K1_OPTIONS[@]} "$@"
     build_from_github libbitcoin libbitcoin master $PARALLEL ${BITCOIN_OPTIONS[@]} "$@"
     build_from_github libbitcoin libbitcoin-consensus master $PARALLEL ${BITCOIN_CONSENSUS_OPTIONS[@]} "$@"

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,17 @@
 
 # Define constants.
 #==============================================================================
+# libbitcoin versions.
+SECP256K1="version4"
+LIBBITCOIN="master"
+LIBBITCOIN_CONSENSUS="master"
+LIBBITCOIN_DATABASE="master"
+LIBBITCOIN_BLOCKCHAIN="master"
+LIBBITCOIN_NETWORK="master"
+LIBBITCOIN_NODE="master"
+LIBBITCOIN_PROTOCOL="master"
+LIBBITCOIN_SERVER="master"
+
 # The default build directory.
 #------------------------------------------------------------------------------
 BUILD_DIR="build-libbitcoin-server"
@@ -736,15 +747,15 @@ build_all()
     if [[ ($BUILD_ZMQ) ]]; then
         build_from_github zeromq libzmq $ZMQ_VERSION $PARALLEL ${ZMQ_OPTIONS[@]} "$@"
     fi
-    build_from_github libbitcoin secp256k1 version4 $PARALLEL ${SECP256K1_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin master $PARALLEL ${BITCOIN_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin-consensus master $PARALLEL ${BITCOIN_CONSENSUS_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin-database master $PARALLEL ${BITCOIN_DATABASE_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin-blockchain master $PARALLEL ${BITCOIN_BLOCKCHAIN_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin-network master $PARALLEL ${BITCOIN_NETWORK_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin-node master $PARALLEL ${BITCOIN_NODE_OPTIONS[@]} "$@"
-    build_from_github libbitcoin libbitcoin-protocol master $PARALLEL ${BITCOIN_PROTOCOL_OPTIONS[@]} "$@"
-    build_from_travis libbitcoin libbitcoin-server master $PARALLEL ${BITCOIN_SERVER_OPTIONS[@]} "$@"
+    build_from_github libbitcoin secp256k1 $SECP256K1 $PARALLEL ${SECP256K1_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin $LIBBITCOIN $PARALLEL ${BITCOIN_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin-consensus $LIBBITCOIN_CONSENSUS $PARALLEL ${BITCOIN_CONSENSUS_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin-database $LIBBITCOIN_DATABASE $PARALLEL ${BITCOIN_DATABASE_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin-blockchain $LIBBITCOIN_BLOCKCHAIN $PARALLEL ${BITCOIN_BLOCKCHAIN_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin-network $LIBBITCOIN_NETWORK $PARALLEL ${BITCOIN_NETWORK_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin-node $LIBBITCOIN_NODE $PARALLEL ${BITCOIN_NODE_OPTIONS[@]} "$@"
+    build_from_github libbitcoin libbitcoin-protocol $LIBBITCOIN_PROTOCOL $PARALLEL ${BITCOIN_PROTOCOL_OPTIONS[@]} "$@"
+    build_from_travis libbitcoin libbitcoin-server $LIBBITCOIN_SERVER $PARALLEL ${BITCOIN_SERVER_OPTIONS[@]} "$@"
 }
 
 


### PR DESCRIPTION
The first commits uses the latest ZMQ version (v.4.2.3) instead of master to build so the install.sh doesn't fail when upstream ZMQ breaks something.

The second commit adds the option to build with a specific libbitcoin branch/tag. e.g. I built it with the latest release (3.5) for my server using the script.


As the install.sh script gets generated from the GSL script I can look into updating that instead, but I wanted to have the discussion if we even want those changes in here first before learning GSL.