### PR TITLE
propagate new bc::settings class

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -130,12 +130,14 @@ bool executor::do_initchain()
         // Unfortunately we are limited to a choice of hardcoded chains.
         auto testnet = metadata_.configured.network.identifier == 118034699u;
         auto regtest = metadata_.configured.network.identifier == 3669344250u;
+        const auto& bitcoin_settings = metadata_.configured.bitcoin;
         const auto genesis =
-            regtest ? block::genesis_regtest() :
-            testnet ? block::genesis_testnet() : block::genesis_mainnet();
+            regtest ? block::genesis_regtest(bitcoin_settings) :
+            testnet ? block::genesis_testnet(bitcoin_settings) :
+                block::genesis_mainnet(bitcoin_settings);
 
         const auto& settings = metadata_.configured.database;
-        const auto result = data_base(settings).create(genesis);
+        const auto result = data_base(settings, bitcoin_settings).create(genesis);
 
         LOG_INFO(LOG_SERVER) << BS_INITCHAIN_COMPLETE;
         return result;

--- a/src/interface/blockchain.cpp
+++ b/src/interface/blockchain.cpp
@@ -517,7 +517,8 @@ void blockchain::stealth_transaction_hashes_fetched(const code& ec,
 void blockchain::broadcast(server_node& node, const message& request,
     send_handler handler)
 {
-    const auto block = std::make_shared<bc::message::block>();
+    const auto block = std::make_shared<bc::message::block>(
+        node.bitcoin_settings());
 
     if (!block->from_data(canonical, request.data()))
     {
@@ -544,7 +545,8 @@ void blockchain::handle_broadcast(const code& ec, const message& request,
 void blockchain::validate(server_node& node, const message& request,
     send_handler handler)
 {
-    const auto block = std::make_shared<bc::message::block>();
+    const auto block = std::make_shared<bc::message::block>(
+        node.bitcoin_settings());
 
     if (!block->from_data(canonical, request.data()))
     {


### PR DESCRIPTION
I'm planning to extend the parser once all constants have been moved into `bc::settings`.