### PR TITLE
Revert "propagate new bc::settings class"

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -128,8 +128,8 @@ bool executor::do_initchain()
         LOG_INFO(LOG_SERVER) << format(BS_INITIALIZING_CHAIN) % directory;
 
         const auto& bitcoin_settings = metadata_.configured.bitcoin;
-        const auto result = data_base(metadata_.configured.database,
-            bitcoin_settings).create(bitcoin_settings.genesis_block);
+        const auto result = data_base(metadata_.configured.database).create(
+            bitcoin_settings.genesis_block);
 
         LOG_INFO(LOG_SERVER) << BS_INITCHAIN_COMPLETE;
         return result;

--- a/src/interface/blockchain.cpp
+++ b/src/interface/blockchain.cpp
@@ -517,8 +517,7 @@ void blockchain::stealth_transaction_hashes_fetched(const code& ec,
 void blockchain::broadcast(server_node& node, const message& request,
     send_handler handler)
 {
-    const auto block = std::make_shared<bc::message::block>(
-        node.bitcoin_settings());
+    const auto block = std::make_shared<bc::message::block>();
 
     if (!block->from_data(canonical, request.data()))
     {
@@ -548,8 +547,7 @@ void blockchain::handle_broadcast(const code& ec, const message& request,
 void blockchain::validate(server_node& node, const message& request,
     send_handler handler)
 {
-    const auto block = std::make_shared<bc::message::block>(
-        node.bitcoin_settings());
+    const auto block = std::make_shared<bc::message::block>();
 
     if (!block->from_data(canonical, request.data()))
     {


### PR DESCRIPTION
This reverts commit d3bbdb4e6ae697bb457236756e2cbd17ae2211b1.

Reason: https://github.com/libbitcoin/libbitcoin/pull/1013