### PR TITLE
Enable a default page to be set on a per-web service endpoint basis

### DIFF
--- a/data/bs.cfg
+++ b/data/bs.cfg
@@ -287,25 +287,23 @@ public_block_endpoint = tcp://*:9073
 public_transaction_endpoint = tcp://*:9074
 # Enable websocket endpoints, defaults to true.
 enabled = true
-# The optional directory for serving files via HTTP/S, defaults to 'web'.
-root = web
-# The SSL certificate authority file, defaults to 'ca.pem', enables secure endpoints.
-ca_certificate = secure/ca.pem
-# The SSL private key file, defaults to 'key.pem', enables secure endpoints.
-server_private_key = secure/key.pem
-# The SSL certificate file, defaults to 'server.pem', enables secure endpoints.
-server_certificate = secure/server.pem
-# The SSL client certificates directory, defaults to 'clients'.
-client_certificates = clients
+# The optional directory for serving files via HTTP/S, defaults to '' (unused).
+#root = web
+# The SSL certificate authority file, defaults to '' (unused), enables secure endpoints.
+#ca_certificate = secure/ca.pem
+# The SSL private key file, defaults to '' (unused), enables secure endpoints.
+#server_private_key = secure/key.pem
+# The SSL certificate file, defaults to '' (unused), enables secure endpoints.
+#server_certificate = secure/server.pem
 # Allowed websocket origin, multiple entries allowed.
-origin = https://localhost:9061
-origin = https://localhost:9062
-origin = https://localhost:9063
-origin = https://localhost:9064
 origin = http://localhost:9071
 origin = http://localhost:9072
 origin = http://localhost:9073
 origin = http://localhost:9074
+origin = https://localhost:9061
+origin = https://localhost:9062
+origin = https://localhost:9063
+origin = https://localhost:9064
 
 [zeromq]
 # The secure query zeromq endpoint, defaults to 'tcp://*:9081'.

--- a/src/web/block_socket.cpp
+++ b/src/web/block_socket.cpp
@@ -38,11 +38,6 @@ using role = zmq::socket::role;
 
 static constexpr auto poll_interval_milliseconds = 100u;
 
-static const std::string block_socket_default
-{
-    "FIXME: Default Block Service page."
-};
-
 block_socket::block_socket(zmq::context& context, server_node& node,
     bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -79,7 +74,11 @@ void block_socket::work()
 
     // Default page data can now be set since the base socket's manager has
     // been initialized.
-    set_default_page_data(block_socket_default);
+    set_default_page_data(http::get_default_page_data(
+        settings_.websockets_query_endpoint(secure_),
+        settings_.websockets_heartbeat_endpoint(secure_),
+        settings_.websockets_block_endpoint(secure_),
+        settings_.websockets_transaction_endpoint(secure_)));
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can
@@ -131,7 +130,7 @@ bool block_socket::handle_block(zmq::socket& subscriber)
         return true;
     }
 
-    uint16_t sequence;
+    uint16_t sequence{};
     uint32_t height;
     data_chunk block_data;
     response.dequeue<uint16_t>(sequence);

--- a/src/web/block_socket.cpp
+++ b/src/web/block_socket.cpp
@@ -38,6 +38,11 @@ using role = zmq::socket::role;
 
 static constexpr auto poll_interval_milliseconds = 100u;
 
+static const std::string block_socket_default
+{
+    "FIXME: Default Block Service page."
+};
+
 block_socket::block_socket(zmq::context& context, server_node& node,
     bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -71,6 +76,10 @@ void block_socket::work()
     LOG_INFO(LOG_SERVER)
         << "Bound " << security_ << " websocket block service to "
         << websocket_endpoint();
+
+    // Default page data can now be set since the base socket's manager has
+    // been initialized.
+    set_default_page_data(block_socket_default);
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can

--- a/src/web/heartbeat_socket.cpp
+++ b/src/web/heartbeat_socket.cpp
@@ -33,6 +33,11 @@ using namespace bc::protocol;
 using namespace bc::system::config;
 using role = zmq::socket::role;
 
+static const std::string heartbeat_socket_default
+{
+    "FIXME: Default Heartbeat Service page."
+};
+
 heartbeat_socket::heartbeat_socket(zmq::context& context, server_node& node,
     bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -67,6 +72,10 @@ void heartbeat_socket::work()
     LOG_INFO(LOG_SERVER)
         << "Bound " << security_ << " websocket heartbeat service to "
         << websocket_endpoint();
+
+    // Default page data can now be set since the base socket's manager has
+    // been initialized.
+    set_default_page_data(heartbeat_socket_default);
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can

--- a/src/web/heartbeat_socket.cpp
+++ b/src/web/heartbeat_socket.cpp
@@ -33,11 +33,6 @@ using namespace bc::protocol;
 using namespace bc::system::config;
 using role = zmq::socket::role;
 
-static const std::string heartbeat_socket_default
-{
-    "FIXME: Default Heartbeat Service page."
-};
-
 heartbeat_socket::heartbeat_socket(zmq::context& context, server_node& node,
     bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -75,7 +70,11 @@ void heartbeat_socket::work()
 
     // Default page data can now be set since the base socket's manager has
     // been initialized.
-    set_default_page_data(heartbeat_socket_default);
+    set_default_page_data(http::get_default_page_data(
+        settings_.websockets_query_endpoint(secure_),
+        settings_.websockets_heartbeat_endpoint(secure_),
+        settings_.websockets_block_endpoint(secure_),
+        settings_.websockets_transaction_endpoint(secure_)));
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can
@@ -128,7 +127,7 @@ bool heartbeat_socket::handle_heartbeat(zmq::socket& subscriber)
         return true;
     }
 
-    uint16_t sequence;
+    uint16_t sequence{};
     uint64_t height;
     response.dequeue<uint16_t>(sequence);
     response.dequeue<uint64_t>(height);

--- a/src/web/query_socket.cpp
+++ b/src/web/query_socket.cpp
@@ -35,6 +35,11 @@ using connection_ptr = http::connection_ptr;
 
 static constexpr auto poll_interval_milliseconds = 100u;
 
+static const std::string query_socket_default
+{
+    "FIXME: Default Query Service page."
+};
+
 query_socket::query_socket(zmq::context& context, server_node& node,
     bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -248,6 +253,10 @@ void query_socket::work()
     LOG_INFO(LOG_SERVER)
         << "Bound " << security_ << " websocket query service to "
         << websocket_endpoint();
+
+    // Default page data can now be set since the base socket's manager has
+    // been initialized.
+    set_default_page_data(query_socket_default);
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can

--- a/src/web/query_socket.cpp
+++ b/src/web/query_socket.cpp
@@ -35,11 +35,6 @@ using connection_ptr = http::connection_ptr;
 
 static constexpr auto poll_interval_milliseconds = 100u;
 
-static const std::string query_socket_default
-{
-    "FIXME: Default Query Service page."
-};
-
 query_socket::query_socket(zmq::context& context, server_node& node,
     bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -256,7 +251,11 @@ void query_socket::work()
 
     // Default page data can now be set since the base socket's manager has
     // been initialized.
-    set_default_page_data(query_socket_default);
+    set_default_page_data(http::get_default_page_data(
+        settings_.websockets_query_endpoint(secure_),
+        settings_.websockets_heartbeat_endpoint(secure_),
+        settings_.websockets_block_endpoint(secure_),
+        settings_.websockets_transaction_endpoint(secure_)));
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can
@@ -323,7 +322,7 @@ bool query_socket::handle_query(zmq::socket& dealer)
         return true;
     }
 
-    uint32_t sequence;
+    uint32_t sequence{};
     data_chunk data;
     std::string command;
 

--- a/src/web/transaction_socket.cpp
+++ b/src/web/transaction_socket.cpp
@@ -36,6 +36,11 @@ using role = zmq::socket::role;
 
 static constexpr auto poll_interval_milliseconds = 100u;
 
+static const std::string transaction_socket_default
+{
+    "FIXME: Default Transaction Service page."
+};
+
 transaction_socket::transaction_socket(zmq::context& context,
     server_node& node, bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -70,6 +75,10 @@ void transaction_socket::work()
     LOG_INFO(LOG_SERVER)
         << "Bound " << security_ << " websocket transaction service to "
         << websocket_endpoint();
+
+    // Default page data can now be set since the base socket's manager has
+    // been initialized.
+    set_default_page_data(transaction_socket_default);
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can

--- a/src/web/transaction_socket.cpp
+++ b/src/web/transaction_socket.cpp
@@ -36,11 +36,6 @@ using role = zmq::socket::role;
 
 static constexpr auto poll_interval_milliseconds = 100u;
 
-static const std::string transaction_socket_default
-{
-    "FIXME: Default Transaction Service page."
-};
-
 transaction_socket::transaction_socket(zmq::context& context,
     server_node& node, bool secure)
   : http::socket(context, node.protocol_settings(), secure),
@@ -78,7 +73,11 @@ void transaction_socket::work()
 
     // Default page data can now be set since the base socket's manager has
     // been initialized.
-    set_default_page_data(transaction_socket_default);
+    set_default_page_data(http::get_default_page_data(
+        settings_.websockets_query_endpoint(secure_),
+        settings_.websockets_heartbeat_endpoint(secure_),
+        settings_.websockets_block_endpoint(secure_),
+        settings_.websockets_transaction_endpoint(secure_)));
 
     // TODO: this should be hidden in socket base.
     // Hold a shared reference to the websocket thread_ so that we can
@@ -131,7 +130,7 @@ bool transaction_socket::handle_transaction(zmq::socket& subscriber)
         return true;
     }
 
-    uint16_t sequence;
+    uint16_t sequence{};
     data_chunk transaction_data;
     response.dequeue<uint16_t>(sequence);
     response.dequeue(transaction_data);


### PR DESCRIPTION
Enable a default page to be set on a per-web service endpoint basis when configurations are not specified.

TODO: improve the default page content.

Requires https://github.com/libbitcoin/libbitcoin-protocol/pull/202