### PR TITLE
Revert fetch history limit default to be unlimited (0).

### DIFF
--- a/src/interface/blockchain.cpp
+++ b/src/interface/blockchain.cpp
@@ -47,7 +47,7 @@ static constexpr auto canonical = system::message::version::level::canonical;
 void blockchain::fetch_history4(server_node& node, const message& request,
     send_handler handler)
 {
-    static constexpr size_t default_limit = bc::max_uint32;
+    static constexpr size_t default_limit = 0;
     static constexpr size_t history_args_size = hash_size + sizeof(uint32_t);
 
     const auto& data = request.data();
@@ -59,7 +59,7 @@ void blockchain::fetch_history4(server_node& node, const message& request,
     }
 
     auto deserial = make_safe_deserializer(data.begin(), data.end());
-    const auto script_hash = deserial.read_hash();
+    const auto script_hash = deserial.read_reverse<hash_digest>();
     const size_t from_height = deserial.read_4_bytes_little_endian();
 
     node.chain().fetch_history(script_hash, default_limit, from_height,


### PR DESCRIPTION
Read reversed history hash to account for reversal done at the client end.