### PR TITLE
Fix streambuf lifetime in electrum test fixture.

### DIFF
--- a/test/protocols/electrum/electrum_setup_fixture.cpp
+++ b/test/protocols/electrum/electrum_setup_fixture.cpp
@@ -113,11 +113,9 @@ boost::json::value electrum_setup_fixture::get(const std::string& request)
 
 boost::json::value electrum_setup_fixture::receive()
 {
-    boost::asio::streambuf stream{};
-
     try
     {
-        boost::asio::read_until(socket_, stream, '\n');
+        boost::asio::read_until(socket_, stream_, '\n');
     }
     catch (const boost::system::system_error&)
     {
@@ -128,7 +126,7 @@ boost::json::value electrum_setup_fixture::receive()
     try
     {
         std::string response{};
-        std::istream response_stream{ &stream };
+        std::istream response_stream{ &stream_ };
         std::getline(response_stream, response);
         return boost::json::parse(response);
     }

--- a/test/protocols/electrum/electrum_setup_fixture.hpp
+++ b/test/protocols/electrum/electrum_setup_fixture.hpp
@@ -50,6 +50,7 @@ private:
     server::server_node server_;
     boost::asio::io_context io{};
     boost::asio::ip::tcp::socket socket_{ io };
+    boost::asio::streambuf stream_{};
 };
 
 struct electrum_ten_block_setup_fixture


### PR DESCRIPTION
```
Fix: make stream_ a member of electrum_setup_fixture so it is reused
across receive() calls, matching the documented contract for read_until.
```