### PR TITLE
fix: blockchain.block.header returns plain hex string when cp_height is zero

### DIFF
--- a/src/protocols/electrum/protocol_electrum_headers.cpp
+++ b/src/protocols/electrum/protocol_electrum_headers.cpp
@@ -235,6 +235,40 @@ void protocol_electrum::blockchain_block_headers(size_t starting,
     const auto links = query.get_confirmed_headers(starting, count);
     auto size = two * chain::header::serialized_size() * links.size();
 
+    // Single header, no proof: spec requires a plain hex string result,
+    // not a {"hex":…} or {"header":…} wrapper object.
+    if (!multiplicity && !prove)
+    {
+        if (links.empty())
+        {
+            send_code(error::server_error);
+            return;
+        }
+        if (at_least(electrum::version::v1_6))
+        {
+            const auto header = query.get_wire_header(links.front());
+            if (header.empty())
+            {
+                send_code(error::server_error);
+                return;
+            }
+            send_result(encode_base16(header), size + 42u);
+        }
+        else
+        {
+            std::string header(size, '\0');
+            stream::out::fast sink{ header };
+            write::base16::fast writer{ sink };
+            if (!query.get_wire_header(writer, links.front()))
+            {
+                send_code(error::server_error);
+                return;
+            }
+            send_result(std::move(header), size + 42u);
+        }
+        return;
+    }
+
     value_t value{ object_t{} };
     auto& result = std::get<object_t>(value.value());
     if (multiplicity)
@@ -283,7 +317,10 @@ void protocol_electrum::blockchain_block_headers(size_t starting,
             }
         };
 
-        result["hex"] = std::move(headers);
+        if (multiplicity)
+            result["hex"] = std::move(headers);
+        else
+            result["header"] = std::move(headers);
     }
 
     // There is a very slim chance of inconsistency given an intervening reorg

--- a/test/protocols/electrum/electrum_headers.cpp
+++ b/test/protocols/electrum/electrum_headers.cpp
@@ -173,12 +173,8 @@ BOOST_AUTO_TEST_CASE(electrum__blockchain_block_header__genesis_no_checkpoint__e
     BOOST_REQUIRE(handshake(electrum::version::v1_3));
 
     const auto response = get(R"({"id":43,"method":"blockchain.block.header","params":[0]})" "\n");
-    REQUIRE_NO_THROW_TRUE(response.at("result").is_object());
-
-    // "hex" prior to v1.6
-    const auto& result = response.at("result").as_object();
-    REQUIRE_NO_THROW_TRUE(result.at("hex").is_string());
-    BOOST_REQUIRE_EQUAL(result.at("hex").as_string(), encode_base16(test::header0_data));
+    REQUIRE_NO_THROW_TRUE(response.at("result").is_string());
+    BOOST_REQUIRE_EQUAL(response.at("result").as_string(), encode_base16(test::header0_data));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__blockchain_block_header__block1_no_checkpoint__expected_no_proof)
@@ -186,8 +182,8 @@ BOOST_AUTO_TEST_CASE(electrum__blockchain_block_header__block1_no_checkpoint__ex
     BOOST_REQUIRE(handshake(electrum::version::v1_6));
 
     const auto response = get(R"({"id":44,"method":"blockchain.block.header","params":[1]})" "\n");
-    REQUIRE_NO_THROW_TRUE(response.at("result").as_object().at("header").is_string());
-    BOOST_REQUIRE_EQUAL(response.at("result").as_object().at("header").as_string(), encode_base16(test::header1_data));
+    REQUIRE_NO_THROW_TRUE(response.at("result").is_string());
+    BOOST_REQUIRE_EQUAL(response.at("result").as_string(), encode_base16(test::header1_data));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__blockchain_block_header__genesis_zero_checkpoint__expected_no_proof)
@@ -195,8 +191,8 @@ BOOST_AUTO_TEST_CASE(electrum__blockchain_block_header__genesis_zero_checkpoint_
     BOOST_REQUIRE(handshake(electrum::version::v1_6));
 
     const auto response = get(R"({"id":45,"method":"blockchain.block.header","params":[0,0]})" "\n");
-    REQUIRE_NO_THROW_TRUE(response.at("result").as_object().at("header").is_string());
-    BOOST_REQUIRE_EQUAL(response.at("result").as_object().at("header").as_string(), encode_base16(test::header0_data));
+    REQUIRE_NO_THROW_TRUE(response.at("result").is_string());
+    BOOST_REQUIRE_EQUAL(response.at("result").as_string(), encode_base16(test::header0_data));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__blockchain_block_header__proof_self_block1__expected)


### PR DESCRIPTION
Per the Electrum protocol spec, blockchain.block.header must return a
plain hex string when cp_height is 0. The shared blockchain_block_headers()
implementation was unconditionally wrapping the result in an object,
causing Electrum clients (e.g. Sparrow) to fail parsing the response.

Two fixes in blockchain_block_headers():
- Add early return for the no-proof singular case that sends a plain
  std::string via send_result() instead of building an object_t.
- Fix the pre-v1.6 proof dict to use "header" for the singular case;
  "hex" is only correct for the plural (concatenated) response.