### PR TITLE
fix blockchain.transaction.get verbose parameter declared required

### DIFF
--- a/include/bitcoin/server/interfaces/electrum.hpp
+++ b/include/bitcoin/server/interfaces/electrum.hpp
@@ -69,7 +69,7 @@ struct electrum_methods
 
         method<"blockchain.transaction.broadcast", string_t>{ "raw_tx" },
         method<"blockchain.transaction.broadcast_package", value_t, optional<false>>{ "raw_txs", "verbose" },
-        method<"blockchain.transaction.get", string_t, boolean_t>{ "tx_hash", "verbose" },
+        method<"blockchain.transaction.get", string_t, optional<false>>{ "tx_hash", "verbose" },
         method<"blockchain.transaction.get_merkle", string_t, number_t>{ "tx_hash", "height" },
         method<"blockchain.transaction.id_from_pos", number_t, number_t, optional<false>>{ "height", "tx_pos", "merkle" },
 

--- a/test/protocols/electrum/electrum_transactions.cpp
+++ b/test/protocols/electrum/electrum_transactions.cpp
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(electrum__blockchain_transaction_get__nonexistent_tx__not_f
     BOOST_REQUIRE_EQUAL(response.at("error").as_object().at("code").as_int64(), not_found.value());
 }
 
-BOOST_AUTO_TEST_CASE(electrum__blockchain_transaction_get__missing_param__dropped)
+BOOST_AUTO_TEST_CASE(electrum__blockchain_transaction_get__missing_verbose__defaults_false)
 {
     BOOST_REQUIRE(handshake(electrum::version::v1_0));
 
@@ -222,7 +222,8 @@ BOOST_AUTO_TEST_CASE(electrum__blockchain_transaction_get__missing_param__droppe
     const auto tx0_hash = encode_hash(coinbase.hash(false));
     const auto request = R"({"id":80,"method":"blockchain.transaction.get","params":["%1%"]})" "\n";
     const auto response = get((boost::format(request) % tx0_hash).str());
-    REQUIRE_NO_THROW_TRUE(response.at("dropped").as_bool());
+    REQUIRE_NO_THROW_TRUE(response.at("result").is_string());
+    BOOST_REQUIRE_EQUAL(response.at("result").as_string(), encode_base16(coinbase.to_data(true)));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__blockchain_transaction_get__extra_param__dropped)


### PR DESCRIPTION
verbose in blockchain.transaction.get was declared as required instead of optional, causing a "missing parameter" error for protocol v1.2+ clients that omit it per spec.