### PR TITLE
fix return hash_function in electrum prior to v1.6

### DIFF
--- a/src/protocols/electrum/protocol_electrum_server.cpp
+++ b/src/protocols/electrum/protocol_electrum_server.cpp
@@ -118,7 +118,7 @@ void protocol_electrum::handle_server_features(const code& ec,
         { "pruning", null_t{} }
     };
 
-    if (!at_least(electrum::version::v1_6))
+    if (at_least(electrum::version::v1_0))
     {
         value["hash_function"] = string_t{ "sha256" };
     }


### PR DESCRIPTION
hash_function should also be returned for protocol versions prior to 1.6 (always sha256) according to specs: [server.features](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-features)