### PR TITLE
fix server.features return hash_function prior v1.7

### DIFF
--- a/src/protocols/electrum/protocol_electrum_server.cpp
+++ b/src/protocols/electrum/protocol_electrum_server.cpp
@@ -118,7 +118,7 @@ void protocol_electrum::handle_server_features(const code& ec,
         { "pruning", null_t{} }
     };
 
-    if (!at_least(electrum::version::v1_6))
+    if (!at_least(electrum::version::v1_7))
     {
         value["hash_function"] = string_t{ "sha256" };
     }

--- a/test/protocols/electrum/electrum_server.cpp
+++ b/test/protocols/electrum/electrum_server.cpp
@@ -167,9 +167,9 @@ BOOST_AUTO_TEST_CASE(electrum__server_features__default_hosts__expected)
     REQUIRE_NO_THROW_TRUE(host.at("ssl_port").is_null());
 }
 
-BOOST_AUTO_TEST_CASE(electrum__server_features__v1_6__hash_function_removed)
+BOOST_AUTO_TEST_CASE(electrum__server_features__v1_7__hash_function_removed)
 {
-    BOOST_REQUIRE(handshake(electrum::version::v1_6));
+    BOOST_REQUIRE(handshake(electrum::version::v1_7));
 
     const auto response = get(R"({"id":300,"method":"server.features","params":[]})" "\n");
     REQUIRE_NO_THROW_TRUE(response.at("result").is_object());


### PR DESCRIPTION
The server.features response now populates hash_function (sha256) for all protocol versions prior to 1.7