### PR TITLE
Fix native protocol reorganized handler: extract header_t not height_t

### DIFF
--- a/src/protocols/native/protocol_native.cpp
+++ b/src/protocols/native/protocol_native.cpp
@@ -213,8 +213,8 @@ bool protocol_native::handle_chase(const code&, node::chase event_,
             if (media != media_type::unknown)
             {
                 // Resets subscriber height to the fork point.
-                BC_ASSERT(std::holds_alternative<node::height_t>(value));
-                POST(do_top, std::get<node::height_t>(value), media);
+                BC_ASSERT(std::holds_alternative<node::header_t>(value));
+                POST(do_top, std::get<node::header_t>(value), media);
             }
 
             break;

--- a/test/protocols/native/native_block.cpp
+++ b/test/protocols/native/native_block.cpp
@@ -160,4 +160,32 @@ BOOST_AUTO_TEST_CASE(native__ws_top_subscribe__progressive_notify__expected)
     BOOST_REQUIRE_EQUAL(to_string(ws_receive()), "0b");
 }
 
+BOOST_AUTO_TEST_CASE(native__reorganized_event__payload_is_header_t__not_height_t)
+{
+    const node::event_value value{ node::header_t{ 11u } };
+    BOOST_REQUIRE(std::get_if<node::header_t>(&value) != nullptr);
+    BOOST_REQUIRE(std::get_if<node::height_t>(&value) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(native__ws_top_subscribe__reorganized__emits_fork_height)
+{
+    BOOST_REQUIRE(!ws_upgrade());
+
+    BOOST_REQUIRE(query_.set(test::mock_block10, database::context{ 0, 10, 0 }, false, false));
+    BOOST_REQUIRE(query_.set(test::mock_block11, database::context{ 0, 11, 0 }, false, false));
+    BOOST_REQUIRE(query_.set(test::mock_block12, database::context{ 0, 12, 0 }, false, false));
+
+    const auto response = ws_get_json("/v1/top/subscribe?format=json");
+    BOOST_REQUIRE(response.is_int64());
+    BOOST_REQUIRE_EQUAL(response.as_int64(), 9);
+
+    BOOST_REQUIRE(query_.push_confirmed(query_.to_header(test::mock_block10.hash()), true));
+    BOOST_REQUIRE_EQUAL(ws_get_text("/v1/top/subscribe?format=text"), "0a");
+
+    BOOST_REQUIRE(query_.push_confirmed(query_.to_header(test::mock_block11.hash()), true));
+    notify(node::chase::reorganized, node::header_t{ 11 });
+
+    BOOST_REQUIRE_EQUAL(to_string(ws_receive()), "0b");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/protocols/native/native_block.cpp
+++ b/test/protocols/native/native_block.cpp
@@ -160,14 +160,7 @@ BOOST_AUTO_TEST_CASE(native__ws_top_subscribe__progressive_notify__expected)
     BOOST_REQUIRE_EQUAL(to_string(ws_receive()), "0b");
 }
 
-BOOST_AUTO_TEST_CASE(native__reorganized_event__payload_is_header_t__not_height_t)
-{
-    const node::event_value value{ node::header_t{ 11u } };
-    BOOST_REQUIRE(std::get_if<node::header_t>(&value) != nullptr);
-    BOOST_REQUIRE(std::get_if<node::height_t>(&value) == nullptr);
-}
-
-BOOST_AUTO_TEST_CASE(native__ws_top_subscribe__reorganized__emits_fork_height)
+BOOST_AUTO_TEST_CASE(native__ws_top_subscribe__reorganized__emits_top_height)
 {
     BOOST_REQUIRE(!ws_upgrade());
 


### PR DESCRIPTION
Fixes #783

protocol_native::handle_chase's `reorganized` case extracted the event payload as node::height_t, but chaser_confirm::set_reorganized posts a header_link (node::header_t), as documented in chase.hpp and as the sibling `organized` case and do_top(node::header_t) already assume.

node::header_t (header_link::integer = uint32_t) and node::height_t (size_t) are distinct alternatives of the event_value variant, so std::get<node::height_t> on a header_t-holding variant throws std::bad_variant_access. handle_chase is NOEXCEPT, so the throw becomes std::terminate: any chain reorganization while a client holds a native `top` subscription crashes the node.

Extract node::header_t instead, matching the emitter, the chase.hpp doc comment, the organized sibling, and do_top's signature.

Adds two regression tests to test/protocols/native/native_block.cpp:
- a non-throwing get_if guard that the reorganized payload is header_t;
- a behavioral test driving the reorganized event through the running server (mirrors native__ws_top_subscribe__progressive_notify__expected). Pre-fix the behavioral case aborts via bad_variant_access; post-fix it passes, so the fix and test land in the same commit.