### PR TITLE
Fix electrum do_reorganized: reset() (not flush()) the status accumulator

### DIFF
--- a/src/protocols/electrum/protocol_electrum.cpp
+++ b/src/protocols/electrum/protocol_electrum.cpp
@@ -195,8 +195,9 @@ void protocol_electrum::do_reorganized(node::header_t) NOEXCEPT
 
     for (auto& [key, sub]: address_subscriptions_)
     {
-        // Flush resets hash accumulator, sub.type remains unchanged.
-        sub.accumulator.flush();
+        // Reset (not flush) the accumulator to its initial (IV) state; flush()
+        // pads in place, leaving non-IV state that would poison re-accumulation.
+        sub.accumulator.reset();
         sub.status = {};
         sub.cursor = {};
     }

--- a/test/protocols/electrum/electrum_subscribe.cpp
+++ b/test/protocols/electrum/electrum_subscribe.cpp
@@ -862,4 +862,48 @@ BOOST_AUTO_TEST_CASE(electrum__blockchain_scriptpubkey_unsubscribe__subscribed__
     REQUIRE_NO_THROW_TRUE(response2.at("result").as_bool());
 }
 
+BOOST_AUTO_TEST_CASE(electrum__blockchain_scripthash_subscribe__reorganized_notify__status_recomputed_clean)
+{
+    BOOST_REQUIRE(handshake(electrum::version::v1_1));
+
+    BOOST_REQUIRE(query_.set(test::mock_block10, database::context{ 0, 10, 0 }, false, false));
+    BOOST_REQUIRE(query_.set(test::mock_block11, database::context{ 0, 11, 0 }, false, false));
+    BOOST_REQUIRE(query_.set(test::mock_block12, database::context{ 0, 12, 0 }, false, false));
+    const auto hash10 = test::mock_block10.transactions_ptr()->at(1)->hash(false);
+    const auto hash11 = test::mock_block11.transactions_ptr()->at(0)->hash(false);
+    const auto hash12 = test::mock_block12.transactions_ptr()->at(0)->hash(false);
+
+    BOOST_REQUIRE(query_.push_confirmed(query_.to_header(test::mock_block10.hash()), true));
+    BOOST_REQUIRE(query_.push_confirmed(query_.to_header(test::mock_block11.hash()), true));
+    BOOST_REQUIRE(query_.push_confirmed(query_.to_header(test::mock_block12.hash()), true));
+
+    const auto expected_confirmed = encode_base16(sha256_hash
+    (
+        encode_hash(hash10) + ":10:" +
+        encode_hash(hash11) + ":11:" +
+        encode_hash(hash12) + ":12:"
+    ));
+
+    const auto request = R"({"id":1101,"method":"blockchain.scripthash.subscribe","params":["%1%"]})" "\n";
+    const auto response1 = get((boost::format(request) % found_scripthash).str());
+    REQUIRE_NO_THROW_TRUE(response1.at("result").is_string());
+    BOOST_REQUIRE_EQUAL(response1.at("result").as_string(), expected_confirmed);
+
+    // Reorg resets the accumulator and clears the cursor; the following organized
+    // event re-folds the unchanged history and must reproduce the same status.
+    notify(node::chase::reorganized);
+    notify(node::chase::organized);
+
+    const auto notification = receive();
+    REQUIRE_NO_THROW_TRUE(notification.at("method").is_string());
+    REQUIRE_NO_THROW_TRUE(notification.at("params").is_array());
+    BOOST_REQUIRE_EQUAL(notification.at("method").as_string(), "blockchain.scripthash.subscribe");
+
+    const auto& params = notification.at("params").as_array();
+    BOOST_REQUIRE_EQUAL(params.size(), 2u);
+    BOOST_REQUIRE(params.at(0).is_string());
+    BOOST_REQUIRE(params.at(1).is_string());
+    BOOST_REQUIRE_EQUAL(params.at(1).as_string(), expected_confirmed);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #785

On a chain regression, protocol_electrum::do_reorganized clears each address subscription's Electrum status-hash cursor and calls accumulator.flush() to clear the persistent midstate. But flush() finalizes the digest in place (non-idempotent, non-destructive) and does not reset the midstate; reset() is the operation intended to reuse the accumulator. Because do_reorganized also clears the cursor, the next confirmed-history scan rebuilds the midstate from height 0 on top of that non-reset state, so the recomputed status hash no longer equals sha256 of the intended "<tx>:<height>:" history string.

Electrum clients key history re-fetch on status equality, so a wrong-but-stable status silently diverges a wallet's view from the chain.

Call reset() instead, which restores the accumulator to its initial state for reuse, so re-accumulation reproduces the correct status.

Adds a regression test
(electrum__blockchain_scripthash_subscribe__reorganized_notify__status_recomputed_clean) mirroring the progressive_notify case: it subscribes over a confirmed history, fires reorganized then organized, and asserts the recomputed pushed status equals the golden hash. Pre-fix it fails (stale midstate); post-fix it passes. The full electrum_tests suite passes.