### PR TITLE
Extend Electrum acceptance tests

### DIFF
--- a/endpoints/.gitignore
+++ b/endpoints/.gitignore
@@ -1,0 +1,3 @@
+/.pytest_cache/
+/__pycache__/
+/venv/

--- a/endpoints/README.md
+++ b/endpoints/README.md
@@ -9,9 +9,10 @@ This directory contains Python-based integration tests for all libbitcoin-server
 | Interface | Protocol | Test File | Status |
 |-----------|----------|-----------|--------|
 | **Native REST** | HTTP/S + JSON | `test_native.py` | ✅ Active |
+| **bitcoind REST** | HTTP/S + JSON/Binary | `test_bitcoind_rest.py` | 🚧 Planned |
 | **bitcoind RPC** | HTTP/S + JSON-RPC 2.0 | `test_bitcoind_rpc.py` | ✅ Active |
 | **Electrum** | TCP + JSON-RPC 2.0 | `test_electrum.py` | ✅ Active |
-| **bitcoind REST** | HTTP/S + JSON/Binary | `test_bitcoind_rest.py` | 🚧 Planned |
+| **Electrum subscriptions** | TCP + push notifications | `test_electrum_subscriptions.py` | ✅ Active |
 | **Stratum v1** | TCP + JSON-RPC 1.0 | `test_stratum_v1.py` | 🚧 Planned |
 | **Stratum v2** | TCP + Binary | `test_stratum_v2.py` | 🚧 Planned |
 
@@ -104,8 +105,8 @@ pytest test_native.py \
 ```
 
 **Available options:**
-- `--native-host` - Host for native/REST (default: localhost)
-- `--native-port` - Port for native/REST (default: 8181)
+- `--native-host` — Host for native/REST (default: localhost)
+- `--native-port` — Port for native/REST (default: 8181)
 
 ### bitcoind RPC Options
 
@@ -124,30 +125,36 @@ pytest test_bitcoind_rpc.py \
 ```
 
 **Available options:**
-- `--bitcoind-rpc-host` - Host for bitcoind RPC (default: localhost)
-- `--bitcoind-rpc-port` - Port for bitcoind RPC (default: 8332)
-- `--bitcoind-auth` - Enable authentication (cookie file)
-- `--bitcoind-cookie` - Path to cookie file (default: /mnt/core/.cookie)
+- `--bitcoind-rpc-host` — Host for bitcoind RPC (default: localhost)
+- `--bitcoind-rpc-port` — Port for bitcoind RPC (default: 8332)
+- `--bitcoind-auth` — Enable authentication (cookie file)
+- `--bitcoind-cookie` — Path to cookie file (default: /mnt/core/.cookie)
 
 ### Electrum Protocol Options
 
 ```bash
 pytest test_electrum.py \
   --electrum-host=localhost \
-  --electrum-port=50001
+  --electrum-port=50001 \
+  --electrum-protocol=1.4:1.6
 ```
 
 **Test against public Electrum server:**
 
 ```bash
 pytest test_electrum.py \
-  --electrum-host=fulcrum.sethforprivacy.com \
+  --electrum-host=bitcoin.lukechilds.co \
   --electrum-port=50001
 ```
 
 **Available options:**
-- `--electrum-host` - Host for Electrum protocol (default: localhost)
-- `--electrum-port` - Port for Electrum protocol (default: 50001)
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--electrum-host` | localhost | Electrum server hostname |
+| `--electrum-port` | 50001 | Electrum server port |
+| `--electrum-protocol` | `1.4:1.6` | Protocol version range offered in the `server.version` handshake. Use `min:max` (e.g. `1.4:1.6`) or a single version (e.g. `1.6`). The server negotiates the highest mutually supported version. |
+| `--subscription-timeout` | 60 | Seconds to wait for a push notification (used by `test_electrum_subscriptions.py`) |
 
 ### General Options
 
@@ -164,7 +171,7 @@ pytest test_native.py \
 
 ## Test Organization
 
-### test_native.py - Native REST
+### test_native.py — Native REST
 
 Tests the `/v1/` HTTP REST endpoints for blockchain exploration.
 
@@ -180,20 +187,13 @@ Tests the `/v1/` HTTP REST endpoints for blockchain exploration.
 **Example test runs:**
 
 ```bash
-# Run all native tests
 pytest test_native.py
-
-# Run only block-related tests
 pytest test_native.py -k "block"
-
-# Run only transaction tests
 pytest test_native.py -k "tx"
-
-# Skip slow address tests
 pytest test_native.py -k "not address"
 ```
 
-### test_bitcoind_rpc.py - bitcoind RPC Compatibility
+### test_bitcoind_rpc.py — bitcoind RPC Compatibility
 
 Tests JSON-RPC 2.0 interface compatible with Bitcoin Core RPC.
 
@@ -205,52 +205,179 @@ Tests JSON-RPC 2.0 interface compatible with Bitcoin Core RPC.
   - pruneblockchain, savemempool, scantxoutset
   - verifychain, verifytxoutset
 - ✅ Error handling
-- ⏭️ Control methods (commented out - 6 methods)
-- ⏭️ Mining methods (commented out - 4 methods)
-- ⏭️ Network methods (commented out - 9 methods)
-- ⏭️ Raw transaction methods (commented out - 9 methods)
+- ⏭️ Control methods (commented out — 6 methods)
+- ⏭️ Mining methods (commented out — 4 methods)
+- ⏭️ Network methods (commented out — 9 methods)
+- ⏭️ Raw transaction methods (commented out — 9 methods)
 
 **Example test runs:**
 
 ```bash
-# Test against libbitcoin-server
 pytest test_bitcoind_rpc.py
-
-# Test against Bitcoin Core (with auth)
 pytest test_bitcoind_rpc.py \
   --bitcoind-rpc-port=9333 \
   --bitcoind-auth \
   --bitcoind-cookie=/path/to/.cookie
-
-# Run only getblock* methods
 pytest test_bitcoind_rpc.py -k "getblock"
 ```
 
-### test_electrum.py - Electrum Protocol
+### test_electrum.py — Electrum Protocol
 
-Tests Electrum Protocol 1.4.2 JSON-RPC over TCP.
+Tests Electrum Protocol JSON-RPC over TCP. All assertions are spec-driven — they
+verify the desired protocol behavior rather than mirroring the current server
+implementation. Failing tests indicate gaps between spec and implementation.
+
+**Architecture:**
+- Single persistent TCP connection for the whole test session
+- `server.version` handshake performed once in the session fixture (the protocol requires it to be the first message sent)
+- Unique monotonic RPC IDs per request: stale delayed responses are discarded automatically
+- Push notifications from active subscriptions filtered out transparently
+- `select()`-based buffered I/O instead of `socket.makefile()` — a timeout on any individual response never corrupts the reader or breaks subsequent tests
 
 **Coverage:**
-- ✅ Server methods (version, banner, features, ping, add_peer, donation_address, peers.subscribe)
-- ✅ Blockchain methods (block.header, block.headers, headers.subscribe, estimatefee, relayfee)
-- ✅ Scripthash methods (balance, history, mempool, listunspent, subscribe, unsubscribe)
-- ✅ Transaction methods (get, get_merkle, id_from_pos, broadcast)
-- ✅ Mempool methods (fee_histogram)
+
+| Category | Tests | Methods |
+|----------|-------|---------|
+| Server | 7 | `server.version`, `server.banner`, `server.features`, `server.ping`, `server.add_peer`, `server.donation_address`, `server.peers.subscribe` |
+| Block header | 3 | `blockchain.block.header` (plain and with cp proof, including protocol doc example) |
+| Block headers | 9 | `blockchain.block.headers` (plain, with cp, bulk, edge cases) |
+| Headers subscribe | 1 | `blockchain.headers.subscribe` (initial response only) |
+| Fee estimation | 2 | `blockchain.estimatefee`, `blockchain.relayfee` |
+| Scripthash | 6 | `blockchain.scripthash.get_balance`, `.get_history`, `.get_mempool`, `.listunspent`, `.subscribe`, `.unsubscribe` |
+| Transactions | 5 | `blockchain.transaction.broadcast`, `.get`, `.get` (verbose), `.get_merkle`, `.id_from_pos` |
+| Mempool | 1 | `mempool.get_fee_histogram` |
+| **Total** | **34** | |
 
 **Example test runs:**
 
 ```bash
-# Test against local Electrum server
+# Local Electrum server (default: localhost:50001, protocol 1.4–1.6)
 pytest test_electrum.py
 
-# Test against public server
-pytest test_electrum.py \
-  --electrum-host=electrum.blockstream.info \
-  --electrum-port=50001
+# Negotiate a specific protocol version
+pytest test_electrum.py --electrum-protocol=1.6
+pytest test_electrum.py --electrum-protocol=1.4:1.4
 
-# Run only server methods
+# Test against a public server
+pytest test_electrum.py --electrum-host=bitcoin.lukechilds.co --electrum-port=50001
+
+# Filter by method group
 pytest test_electrum.py -k "server"
+pytest test_electrum.py -k "scripthash"
+pytest test_electrum.py -k "block_header"
+
+# Debug mode (pretty-print every JSON-RPC message)
+ELECTRUM_DEBUG=1 pytest test_electrum.py -s -k "block_header"
 ```
+
+### test_electrum_subscriptions.py — Push Notification Tests
+
+Tests that subscribe to server events and wait for real blockchain push notifications.
+Requires a live node with active network traffic and much longer timeouts than the
+regular request/response tests. Each test opens its own fresh TCP connection.
+
+```bash
+pytest test_electrum_subscriptions.py
+pytest test_electrum_subscriptions.py --subscription-timeout=120
+
+# Optional: trigger a block/tx event to avoid waiting the full timeout
+ELECTRUM_TRIGGER_HEADERS="bitcoin-cli generatetoaddress 1 <address>" \
+  pytest test_electrum_subscriptions.py
+```
+
+**Tests:**
+- `test_headers_notification` — subscribes to `blockchain.headers.subscribe`, waits for a block notification, validates `{method, params: [{height, hex}]}` format
+- `test_scripthash_notification` — subscribes to `blockchain.scripthash.subscribe`, waits for a status-change notification, validates `{method, params: [scripthash, status]}` format
+
+---
+
+## Electrum Protocol Version Reference
+
+The Electrum protocol has evolved across versions. This table shows which methods exist in which version and where behavior differs. The test suite uses version-conditional assertions where applicable, based on the negotiated version returned by the `server.version` handshake.
+
+| Method / Behavior | v1.0 | v1.1 | v1.2 | v1.3 | v1.4 | v1.4.2 | v1.6 |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Server** | | | | | | | |
+| `server.version` | ✅ | ✅ | ✅ | ✅ | ✅ ¹ | ✅ ¹ | ✅ ¹ |
+| `server.banner` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `server.features` | — | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `server.ping` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `server.add_peer` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `server.donation_address` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `server.peers.subscribe` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Block Header** | | | | | | | |
+| `blockchain.block.header` | — ² | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.block.header` with `cp_height` | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| → response key: `"header"` (160-char hex) | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| → response key: `"branch"` (list of 64-char hashes) | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| → response key: `"root"` (64-char merkle root) | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Block Headers** | | | | | | | |
+| `blockchain.block.headers` | — | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| → response key: `"hex"` (concatenated hex string) | — | — | ✅ | ✅ | ✅ | ✅ | — ³ |
+| → response key: `"headers"` (array of 160-char hex) | — | — | — | — | — | — | ✅ ³ |
+| `blockchain.block.headers` with `cp_height` | — | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Headers Subscribe** | | | | | | | |
+| `blockchain.headers.subscribe` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| → deserialized: `{block_height, version, prev_block_hash, …}` | ✅ | ✅ | ✅ | — | — | — | — |
+| → serialized raw: `{height, hex}` (hex = 160 chars) | — | — | — | ✅ | ✅ | ✅ | ✅ |
+| **Fee Estimation** | | | | | | | |
+| `blockchain.estimatefee` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.relayfee` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✗ ⁴ |
+| **Scripthash** | | | | | | | |
+| `blockchain.scripthash.get_balance` | — ⁵ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.scripthash.get_history` | — ⁵ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.scripthash.get_mempool` | — ⁵ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.scripthash.listunspent` | — ⁵ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.scripthash.subscribe` | — ⁵ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.scripthash.unsubscribe` | — | — | — | — | ✅ | ✅ | ✅ |
+| **Transactions** | | | | | | | |
+| `blockchain.transaction.broadcast` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.transaction.get` (raw hex) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.transaction.get` (verbose) | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.transaction.get_merkle` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `blockchain.transaction.id_from_pos` | — | — | — | — | ✅ | ✅ | ✅ |
+| **Mempool** | | | | | | | |
+| `mempool.get_fee_histogram` | — | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+**Legend:** ✅ available and expected to work · — not yet introduced in this version · ✗ removed
+
+**Footnotes:**
+
+¹ Since v1.4, `server.version` must be the **first** message sent by the client. Any other message sent first results in a protocol error. The test suite performs the handshake as the session fixture before any test runs.
+
+² v1.0 used `blockchain.block.get_header` (different method name). `blockchain.block.header` was introduced in v1.1.
+
+³ In v1.6, `blockchain.block.headers` changed its data format: the `"hex"` key (a single concatenated hex string of all headers) was replaced by `"headers"` (an array of individual 160-char hex strings). The test suite accepts either key, determined by which one is present in the response.
+
+⁴ `blockchain.relayfee` was removed in v1.6. Clients should read `server.features["fee_rate"]` instead. When `negotiated_version >= "1.6"`, the test verifies that the server rejects the call with any error (libbitcoin-server returns `wrong_version`; ElectrumX returns `-32601 unknown method` — both are valid rejections).
+
+⁵ v1.0 used `blockchain.address.*` (address-based methods). Scripthash-based methods (`blockchain.scripthash.*`) were introduced in v1.1.
+
+### Version-Conditional Test Assertions
+
+The following tests adjust their assertions based on `negotiated_version` from the `server.version` handshake:
+
+| Test | Condition | Expected behavior |
+|------|-----------|-------------------|
+| `test_blockchain_headers_subscribe` | `< "1.3"` | Response has `block_height` (int) and at least one of `version`, `prev_block_hash`, `merkle_root` |
+| `test_blockchain_headers_subscribe` | `>= "1.3"` | Response has `height` (int) and `hex` (160-char string) |
+| `test_blockchain_relayfee` | `< "1.6"` | Returns a positive `float` (BTC/kB) |
+| `test_blockchain_relayfee` | `>= "1.6"` | Server must reject with any error; test passes if `ValueError` is raised |
+| `test_blockchain_block_headers` (all variants) | `< "1.6"` | Result dict has `"hex"` key (concatenated string, length = `count × 160`) |
+| `test_blockchain_block_headers` (all variants) | `>= "1.6"` | Result dict has `"headers"` key (array, each element 160 chars) |
+
+### Known Deviations from Spec
+
+These are the four `⚠️ xfail` outcomes when running against libbitcoin-server. Each is documented here so the expected test result is not mistaken for a regression.
+
+| Test | Server response | Spec-correct behavior | Status |
+|------|-----------------|-----------------------|--------|
+| `test_server_add_peer` | `not_implemented` | Must return `bool` | Gap — peer list management not implemented |
+| `test_blockchain_block_headers_count_zero` | `not_found` error | Should return `{count: 0, hex: ""}` | Gap — count=0 is not prohibited by the spec |
+| `test_blockchain_block_headers_cp_target_overflow` | `target_overflow` error | Error is correct — `cp_height < target` is invalid | By design — the test triggers this deliberately |
+| `test_blockchain_transaction_broadcast` | error (invalid tx) | Error is correct — 10-byte payload is not a valid transaction | By design — the test exercises the broadcast rejection path |
+
+---
 
 ## Advanced Usage
 
@@ -276,8 +403,8 @@ pytest test_native.py -m "not skip"
 # Run only slow tests
 pytest test_native.py -m "slow"
 
-# Run parametrized tests with specific parameter
-pytest test_native.py -k "filter_type-bloom"
+# Run subscription tests
+pytest test_electrum_subscriptions.py
 ```
 
 ### Output Formats
@@ -306,25 +433,29 @@ pytest -x
 pytest -n 4
 ```
 
+---
+
 ## Test Data Reference
 
 All tests use shared reference data from `utils.ReferenceData`:
 
-| Item | Value | Description |
-|------|-------|-------------|
-| **GENESIS_HEIGHT** | 0 | Genesis block height |
-| **GENESIS_HASH** | 000000000019d668... | Genesis block hash |
-| **KNOWN_HEIGHT** | 9000 | Test block height |
-| **KNOWN_BLOCK_HASH** | 00000000415c7a0f... | Test block hash (height 9000) |
-| **KNOWN_TX_HASH** | a5f71a0b4ccda01f... | Coinbase tx at height 9000 |
-| **EXAMPLE_SCRIPTHASH** | 6e8c6c7183154cae... | Test scripthash with activity |
-| **SEGWIT_HEIGHT** | 481824 | First SegWit-enforced block (24 Aug 2017) |
-| **SEGWIT_BLOCK_HASH** | 0000000000000000001c... | Block hash at height 481824 |
-| **SEGWIT_TX_HASH_P2WPKH** | dfcec48bb8491856... | First native P2WPKH tx (witness inputs) |
-| **SEGWIT_TX_HASH_P2WPKH2** | f91d0a8a78462bc5... | Second native P2WPKH tx in block 481824 |
-| **SEGWIT_TX_HASH_P2WSH** | 461e8a4aa0a0e75c... | Tx with P2WSH output in block 481824 |
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `GENESIS_HEIGHT` | 0 | Genesis block height |
+| `GENESIS_HASH` | `000000000019d668…` | Genesis block hash |
+| `KNOWN_HEIGHT` | 9000 | Test block height |
+| `KNOWN_BLOCK_HASH` | `00000000415c7a0f…` | Test block hash (height 9000) |
+| `KNOWN_TX_HASH` | `a5f71a0b4ccda01f…` | Coinbase tx at height 9000 |
+| `EXAMPLE_SCRIPTHASH` | `6e8c6c7183154cae…` | Test scripthash with confirmed activity |
+| `SEGWIT_HEIGHT` | 481824 | First SegWit-enforced block (24 Aug 2017) |
+| `SEGWIT_BLOCK_HASH` | `0000000000000000001c…` | Block hash at height 481824 |
+| `SEGWIT_TX_HASH_P2WPKH` | `dfcec48bb8491856…` | First native P2WPKH tx (witness inputs) |
+| `SEGWIT_TX_HASH_P2WPKH2` | `f91d0a8a78462bc5…` | Second native P2WPKH tx in block 481824 |
+| `SEGWIT_TX_HASH_P2WSH` | `461e8a4aa0a0e75c…` | Tx with P2WSH output in block 481824 |
 
 > **Note:** Witness data (`input/witness`) requires a SegWit transaction. Tests using `SEGWIT_TX_HASH_P2WPKH` will fail or be skipped if the node is not synced past block **481,824**.
+
+---
 
 ## Troubleshooting
 
@@ -334,37 +465,45 @@ All tests use shared reference data from `utils.ReferenceData`:
 ```
 RuntimeError: RPC connection error: ConnectionRefusedError
 ```
-**Solution:** Ensure libbitcoin-server is running and the endpoint is enabled in configuration.
+Ensure libbitcoin-server is running and the endpoint is enabled in configuration.
 
 **2. Timeout errors**
 ```
 requests.exceptions.ReadTimeout: HTTPConnectionPool(...): Read timed out
 ```
-**Solution:** Increase timeout with `--timeout=60` or check server performance.
+Increase timeout with `--timeout=60` or check server performance.
 
-**3. Test failures on public servers**
-```
-pytest.xfail: Server error: Method not found
-```
-**Solution:** Public servers may not implement all methods. This is expected and tests will skip gracefully.
+**3. Tests skip after a timeout on a previous test**
 
-**4. Authentication errors (Bitcoin Core)**
+The Electrum test suite uses `select()`-based I/O on a module-level byte buffer. A timeout on one test does **not** corrupt the socket reader — the buffer is intact and subsequent tests continue normally. If you see cascading skips, the server likely closed the connection (check server logs for `unexpected method` or `channel stop`).
+
+**4. `unexpected method` in server log / cascading skips**
+
+libbitcoin-server closes the TCP connection when it receives an unknown method name. Ensure the method name is spelled exactly as in the Electrum spec — notably `blockchain.scripthash.listunspent` (no underscore between `list` and `unspent`), unlike the underscore convention used by `get_balance` / `get_history`.
+
+**5. Test failures on public servers**
+```
+SKIP: No response (possibly unsupported method)
+```
+Some public servers (electrs in particular) do not implement all Electrum methods and simply do not respond. The test skips cleanly. This is not a test failure.
+
+**6. Authentication errors (Bitcoin Core)**
 ```
 RuntimeError: RPC connection error: 401 Unauthorized
 ```
-**Solution:** Use `--bitcoind-auth --bitcoind-cookie=/correct/path/.cookie`
+Use `--bitcoind-auth --bitcoind-cookie=/correct/path/.cookie`
 
-**5. Import errors**
+**7. Import errors**
 ```
 ModuleNotFoundError: No module named 'utils'
 ```
-**Solution:** Run pytest from the `test/endpoints/` directory or install package in development mode.
+Run pytest from the `test/endpoints/` directory or install package in development mode.
 
-### Request/Response Debug Output
+### Debug Output
 
-Each test module supports a dedicated environment variable that enables pretty-printed JSON logging of every request and response:
+Each test module supports a debug environment variable that enables pretty-printed JSON logging of every request and response:
 
-| Test file | Variable | Prints |
+| Test file | Variable | Output |
 |-----------|----------|--------|
 | `test_electrum.py` | `ELECTRUM_DEBUG=1` | `>>>` JSON-RPC payload / `<<<` response with elapsed time |
 | `test_native.py` | `NATIVE_DEBUG=1` | `>>> GET <url>` / `<<<` response JSON with elapsed time |
@@ -374,33 +513,11 @@ Each test module supports a dedicated environment variable that enables pretty-p
 # Electrum — pretty-print all requests and responses
 ELECTRUM_DEBUG=1 pytest test_electrum.py -s
 
-# Native REST
-NATIVE_DEBUG=1 pytest test_native.py -s
-
-# bitcoind RPC
-BITCOIND_DEBUG=1 pytest test_bitcoind_rpc.py -s
-
 # Combine with -k to focus on a single test
 ELECTRUM_DEBUG=1 pytest test_electrum.py -s -k "block_headers_20000"
 ```
 
-> **Note:** Use `-s` (or `--capture=no`) together with the debug variable so pytest does not suppress stdout.
-
-### Debug Mode
-
-```bash
-# Enable Python debugger on test failure
-pytest --pdb
-
-# Show local variables on failure
-pytest -l
-
-# Capture and display stdout/stderr
-pytest -s
-
-# Full traceback
-pytest --tb=long
-```
+> Use `-s` (or `--capture=no`) together with the debug variable so pytest does not suppress stdout.
 
 ### Performance Profiling
 
@@ -410,47 +527,66 @@ pytest --durations=10
 
 # Profile test execution (requires pytest-profiling)
 pytest --profile
-
-# Benchmark tests (requires pytest-benchmark)
-pytest --benchmark-only
 ```
+
+---
 
 ## Writing New Tests
 
-### Test Structure Template
+### Electrum Test Structure
+
+Electrum tests share a single persistent connection. Use `send_rpc()` for all calls inside tests — it handles connection errors (skip), server errors (xfail), and stale responses automatically.
+
+```python
+def test_new_electrum_method():
+    result = send_rpc("some.method", [param1, param2])
+    assert isinstance(result, dict)
+    assert "expected_field" in result
+```
+
+For version-conditional assertions:
+
+```python
+def test_version_dependent():
+    result = send_rpc("blockchain.headers.subscribe")
+    if negotiated_version is not None and negotiated_version >= "1.3":
+        assert "height" in result and "hex" in result
+    else:
+        assert "block_height" in result
+```
+
+For methods that must be rejected in a specific version, bypass `send_rpc()` and use `_rpc_raw()` directly so you can catch the `ValueError`:
+
+```python
+def test_method_removed_in_v16():
+    if negotiated_version is not None and negotiated_version >= "1.6":
+        try:
+            _rpc_raw("some.removed.method")
+            pytest.fail("Method should be rejected in v1.6+")
+        except ValueError:
+            pass
+        return
+    result = send_rpc("some.removed.method")
+    assert result > 0
+```
+
+### Native REST Test Structure
 
 ```python
 def test_new_endpoint(native_config):
-    """Test description."""
-    # Arrange
-    endpoint = "new/endpoint"
-
-    # Act
-    data = get_json(native_config["base_url"], endpoint)
-
-    # Assert
+    data = get_json(native_config["base_url"], "new/endpoint")
     assert isinstance(data, dict)
     assert "expected_field" in data
 ```
 
-### Using Fixtures
+### Fixtures
 
-```python
-# Use native_config for REST tests
-def test_with_config(native_config):
-    url = native_config["base_url"]
-    host = native_config["host"]
-    port = native_config["port"]
-
-# Use bitcoind_rpc_config for RPC tests
-def test_rpc_method(bitcoind_rpc_config):
-    response = send_rpc(bitcoind_rpc_config, "method_name", [params])
-
-# Use electrum_config for Electrum tests
-def test_electrum_method(electrum_config):
-    # Connection is managed by fixture
-    result = send_rpc("electrum.method", [params])
-```
+| Fixture | Scope | Use for |
+|---------|-------|---------|
+| `native_config` | session | Native REST tests — provides `base_url`, `host`, `port` |
+| `bitcoind_rpc_config` | session | bitcoind RPC tests — provides `url`, `auth`, `timeout` |
+| `electrum_config` | session | Electrum tests — provides `host`, `port`, `protocol`, `timeout` |
+| `persistent_connection` | session | Electrum session socket — autouse, performs handshake |
 
 ### Parametrized Tests
 
@@ -466,16 +602,18 @@ def test_getblockhash(bitcoind_rpc_config, height, expected_hash):
     assert response["result"] == expected_hash
 ```
 
+---
+
 ## Contributing
 
 When adding new tests:
 
 1. Follow existing code structure and naming conventions
 2. Use shared utilities from `utils.py`
-3. Add docstrings explaining what each test validates
-4. Use appropriate pytest markers (`@pytest.mark.skip`, `@pytest.mark.parametrize`)
-5. Handle expected errors gracefully (use `pytest.xfail`, `pytest.skip`)
-6. Update this README with new test coverage
+3. Assert the **spec-required** behavior, not just what the current server returns — failing tests are how we find implementation gaps
+4. Use `pytest.xfail` (via `send_rpc`) for errors that are correct by design; use `pytest.skip` for missing prerequisites
+5. Handle version-conditional behavior with `negotiated_version` comparisons
+6. Update the Cross-Server Compatibility table in this README after verifying against multiple servers
 
 ## Resources
 
@@ -483,6 +621,7 @@ When adding new tests:
 - [libbitcoin-server Documentation](../../docs/)
 - [Bitcoin Core RPC Documentation](https://developer.bitcoin.org/reference/rpc/)
 - [Electrum Protocol Documentation](https://electrumx.readthedocs.io/en/latest/protocol.html)
+- [Electrum Protocol Changelog](https://electrumx.readthedocs.io/en/latest/protocol-changes.html)
 - [libbitcoin-server GitHub](https://github.com/libbitcoin/libbitcoin-server)
 
 ## License

--- a/endpoints/conftest.py
+++ b/endpoints/conftest.py
@@ -78,6 +78,24 @@ def pytest_addoption(parser):
         default="50001",
         help="Port for Electrum protocol (default: 50001)"
     )
+    parser.addoption(
+        "--electrum-protocol",
+        action="store",
+        default="1.4:1.6",
+        help=(
+            "Electrum protocol version range offered in the server.version handshake. "
+            "Use 'min:max' (e.g. '1.4:1.6') or a single version (e.g. '1.6'). "
+            "The server will negotiate the highest mutually supported version. "
+            "(default: 1.4:1.6)"
+        )
+    )
+
+    parser.addoption(
+        "--subscription-timeout",
+        action="store",
+        default="60",
+        help="Timeout in seconds for subscription/notification tests (default: 60)"
+    )
 
     # Stratum v1 options
     parser.addoption(
@@ -114,6 +132,13 @@ def pytest_addoption(parser):
         default="30",
         help="Default timeout for requests in seconds (default: 30)"
     )
+
+
+def pytest_report_header(config):
+    host = config.getoption("--electrum-host")
+    port = config.getoption("--electrum-port")
+    proto = config.getoption("--electrum-protocol")
+    return [f"electrum: {host}:{port}  protocol offered: {proto}"]
 
 
 @pytest.fixture(scope="session")
@@ -175,10 +200,18 @@ def bitcoind_rest_config(request):
 @pytest.fixture(scope="session")
 def electrum_config(request):
     """Configuration for Electrum protocol tests."""
+    proto_str = request.config.getoption("--electrum-protocol")
+    if ":" in proto_str:
+        proto_min, proto_max = proto_str.split(":", 1)
+    else:
+        proto_min = proto_max = proto_str.strip()
+
     return {
         "host": request.config.getoption("--electrum-host"),
         "port": int(request.config.getoption("--electrum-port")),
-        "timeout": float(request.config.getoption("--timeout"))
+        "timeout": float(request.config.getoption("--timeout")),
+        "protocol": [proto_min.strip(), proto_max.strip()],
+        "subscription_timeout": float(request.config.getoption("--subscription-timeout")),
     }
 
 

--- a/endpoints/test_electrum.py
+++ b/endpoints/test_electrum.py
@@ -1,75 +1,206 @@
 """
 Tests for libbitcoin-server Electrum protocol compatibility interface.
 
-Tests the Electrum Protocol 1.4.2 JSON-RPC over TCP interface
-for wallet and blockchain queries.
+Tests the Electrum Protocol JSON-RPC over TCP interface for wallet and
+blockchain queries. All assertions represent the *desired* protocol behavior
+per the Electrum specification — not just what the current server happens to
+return. Failing tests indicate gaps between spec and implementation.
+
+Connection management: a single persistent TCP connection is shared across
+the test session. The Electrum version handshake (server.version) is
+performed once during session setup using the configured protocol range.
 
 Run with:
-    pytest test_electrumx.py
-    pytest test_electrumx.py --electrum-host=localhost --electrum-port=50001
-    pytest test_electrumx.py --electrum-host=fulcrum.sethforprivacy.com --electrum-port=50001
+    pytest test_electrum.py
+    pytest test_electrum.py --electrum-host=localhost --electrum-port=50001
+    pytest test_electrum.py --electrum-protocol=1.6
+    pytest test_electrum.py --electrum-host=fulcrum.sethforprivacy.com --electrum-port=50001
+    ELECTRUM_DEBUG=1 pytest test_electrum.py -s -k "block_header"
+
+For tests that wait for real push notifications see test_electrum_subscriptions.py:
+    pytest test_electrum_subscriptions.py --subscription-timeout=120
 """
 
 import json
 import os
+import select
 import socket
 import time
-import subprocess
 import warnings
 import pytest
+from typing import Any
 
 from utils import ReferenceData, TestConfig
 
+_CLIENT_NAME = "libbitcoin-server-test/1.0"
 
-# Global persistent connection (managed by fixture)
-sock = None
-reader = None
+# ─── Module-level session state ──────────────────────────────────────────────
+_sock: socket.socket | None = None
+_recv_buffer: bytes = b""
+_configured_protocol: list[str] = ["1.4", "1.6"]
+_server_name: str | None = None
+negotiated_version: str | None = None
+_next_rpc_id: int = 1
 
+
+# ─── Session fixture ─────────────────────────────────────────────────────────
 
 @pytest.fixture(autouse=True, scope="session")
-def persistent_connection(electrum_config):
-    """Establish persistent connection for entire test session."""
-    global sock, reader
+def persistent_connection(electrum_config: dict):
+    """
+    Establish a persistent TCP connection and perform the Electrum version
+    handshake. The negotiated version is stored in `negotiated_version` for
+    test assertions.
+    """
+    global _sock, _recv_buffer, _configured_protocol, _server_name, negotiated_version
 
     host = electrum_config["host"]
     port = electrum_config["port"]
     timeout = electrum_config.get("timeout", TestConfig.DEFAULT_SOCKET_TIMEOUT)
+    protocol = electrum_config.get("protocol", ["1.4", "1.6"])
+
+    _configured_protocol = protocol
+    _recv_buffer = b""
+    _server_name = None
+    negotiated_version = None
 
     try:
-        sock = socket.create_connection((host, port), timeout=timeout)
-        reader = sock.makefile('r', encoding='utf-8')
+        _sock = socket.create_connection((host, port), timeout=timeout)
+    except OSError as exc:
+        pytest.exit(f"Cannot connect to Electrum server at {host}:{port}: {exc}", returncode=1)
+
+    # server.version MUST be the first message sent (Electrum protocol requirement).
+    # Store the result; test_server_version validates it.
+    try:
+        handshake = _rpc_raw("server.version", [_CLIENT_NAME, protocol], timeout_s=timeout)
+        if isinstance(handshake, list) and len(handshake) >= 2:
+            _server_name = str(handshake[0])
+            negotiated_version = str(handshake[1])
+    except Exception:
+        pass  # test_server_version will fail with a clear message
+
+    proto_display = protocol[0] if protocol[0] == protocol[1] else f"{protocol[0]}:{protocol[1]}"
+    if negotiated_version is not None:
+        print(
+            f"\n  server:     {_server_name}\n"
+            f"  negotiated: {negotiated_version}  (offered: {proto_display})",
+            flush=True,
+        )
+    else:
+        print(f"\n  Electrum handshake failed — {host}:{port} (offered: {proto_display})", flush=True)
+
+    try:
         yield
     finally:
-        if reader is not None:
+        s, _sock = _sock, None
+        if s is not None:
             try:
-                reader.close()
-            except:
-                pass
-        if sock is not None:
-            try:
-                sock.close()
-            except:
+                s.close()
+            except Exception:
                 pass
 
 
-def send_rpc(method: str, params: list = None):
+# ─── Low-level I/O ───────────────────────────────────────────────────────────
+
+def _readline(timeout_s: float | None = None) -> str | None:
     """
-    Send Electrum JSON-RPC request over persistent TCP connection.
+    Read one newline-terminated line from the persistent socket.
 
-    Args:
-        method: Electrum method name (e.g., "server.version")
-        params: Optional list of parameters
+    Maintains a module-level byte buffer so a timeout on any individual
+    recv() never corrupts reader state. This is critical: Python's
+    socket.makefile() marks itself permanently unreadable after the first
+    timeout (SocketIO._timeout_occurred), which would break the entire test
+    session. The select-based approach avoids that.
 
-    Returns:
-        Response result (extracted from JSON-RPC wrapper)
-
-    Raises:
-        pytest.skip: On unsupported methods or connection errors
-        pytest.xfail: On server errors
+    Returns the decoded line without the trailing newline, or None on
+    timeout or connection close.
     """
+    global _recv_buffer
+
+    deadline = time.monotonic() + timeout_s if timeout_s is not None else None
+
+    while True:
+        nl = _recv_buffer.find(b"\n")
+        if nl >= 0:
+            line, _recv_buffer = _recv_buffer[:nl], _recv_buffer[nl + 1:]
+            return line.decode("utf-8", errors="replace")
+
+        if _sock is None:
+            return None
+
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            # select() avoids touching the socket when nothing is ready,
+            # so a timeout here leaves the buffer intact for the next call.
+            ready, _, _ = select.select([_sock], [], [], remaining)
+            if not ready:
+                return None
+
+        try:
+            chunk = _sock.recv(65536)
+        except OSError:
+            return None
+
+        if not chunk:
+            return None  # server closed connection
+        _recv_buffer += chunk
+
+
+def _rpc_raw(method: str, params: list | None = None,
+             timeout_s: float = TestConfig.DEFAULT_SOCKET_TIMEOUT) -> Any:
+    """
+    Send a JSON-RPC request and return the parsed result without any pytest
+    skip/xfail handling. Used internally (e.g. in the handshake fixture).
+    Raises RuntimeError on connection/protocol errors.
+    """
+    if _sock is None:
+        raise RuntimeError("No socket connection")
+
     payload = {
         "jsonrpc": "2.0",
         "id": 0,
+        "method": method,
+        "params": params if params is not None else [],
+    }
+    _sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+
+    data = _readline(timeout_s=timeout_s)
+    if data is None:
+        raise RuntimeError(f"No response for {method!r}")
+
+    resp = json.loads(data)
+    if isinstance(resp, dict) and resp.get("error") is not None:
+        raise ValueError(str(resp["error"]))
+    if isinstance(resp, dict) and "result" in resp:
+        return resp["result"]
+    return resp
+
+
+# ─── Public RPC helper used by tests ────────────────────────────────────────
+
+def send_rpc(method: str, params: list | None = None) -> Any:
+    """
+    Send an Electrum JSON-RPC request and return the result.
+
+    Each request gets a unique monotonic ID so that stale delayed responses
+    from a previous timed-out request are silently discarded rather than
+    poisoning the next test.
+
+    Push notifications (server-initiated messages while a subscription is
+    active) are also transparently skipped.
+
+    On connection or timeout errors the current test is skipped.
+    On server-reported errors the current test is xfailed.
+    """
+    global _next_rpc_id
+    rpc_id = _next_rpc_id
+    _next_rpc_id += 1
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": rpc_id,
         "method": method,
         "params": params if params is not None else [],
     }
@@ -78,119 +209,80 @@ def send_rpc(method: str, params: list = None):
         if os.getenv("ELECTRUM_DEBUG"):
             print(">>>", json.dumps(payload, indent=2), flush=True)
 
-        sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+        if _sock is None:
+            pytest.skip("No socket connection")
 
-        _t0 = time.monotonic()
-        data = reader.readline().rstrip("\n")
-        _elapsed = time.monotonic() - _t0
+        _sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
 
-        if not data:
-            pytest.skip(f"No response (possibly unsupported method: {method})")
+        timeout = TestConfig.DEFAULT_SOCKET_TIMEOUT
+        t0 = time.monotonic()
 
-        response = parse_response(data)
+        while True:
+            remaining = timeout - (time.monotonic() - t0)
+            if remaining <= 0:
+                pytest.skip(f"Timeout waiting for response to {method!r}")
 
-        # Pretty print parsed response when debugging
-        if os.getenv("ELECTRUM_DEBUG"):
-            try:
-                print(f"<<< {method} ({_elapsed * 1000:.1f} ms):", json.dumps(response, indent=2), flush=True)
-            except Exception:
-                pass
+            data = _readline(timeout_s=remaining)
+            if data is None:
+                pytest.skip(f"No response (possibly unsupported method: {method!r})")
 
-        # Check for error in response
-        if isinstance(response, dict) and "error" in response and response["error"] is not None:
-            err = response["error"]
-            msg = err.get("message", str(err)) if isinstance(err, dict) else str(err)
-            pytest.xfail(f"Server error: {msg}")
+            response = _parse_response(data, method)
 
-        # Extract result
-        if isinstance(response, dict):
-            return response.get("result")
-        else:
+            if isinstance(response, dict):
+                # Skip push notifications: 'method' key present, no 'result'.
+                if "method" in response and "result" not in response:
+                    if os.getenv("ELECTRUM_DEBUG"):
+                        print(f"<<< [skip notification] {response.get('method')!r}", flush=True)
+                    continue
+                # Discard stale responses from timed-out previous requests.
+                resp_id = response.get("id")
+                if resp_id is not None and resp_id != rpc_id:
+                    if os.getenv("ELECTRUM_DEBUG"):
+                        print(f"<<< [discard stale id={resp_id}] {method!r}", flush=True)
+                    continue
+
+            if os.getenv("ELECTRUM_DEBUG"):
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                try:
+                    print(f"<<< {method} ({elapsed_ms:.1f} ms):",
+                          json.dumps(response, indent=2), flush=True)
+                except Exception:
+                    pass
+
+            if isinstance(response, dict) and response.get("error") is not None:
+                err = response["error"]
+                msg = err.get("message", str(err)) if isinstance(err, dict) else str(err)
+                pytest.xfail(f"Server error: {msg}")
+
+            if isinstance(response, dict) and "result" in response:
+                return response["result"]
             return response
 
-    except Exception as e:
-        pytest.skip(f"Connection / protocol error: {type(e).__name__}: {e}")
+    except (pytest.skip.Exception, pytest.xfail.Exception):
+        raise
+    except Exception as exc:
+        pytest.skip(f"Connection / protocol error: {type(exc).__name__}: {exc}")
 
 
-def _read_raw_line(timeout: float):
-    """Read a raw line from the persistent reader with a timeout (returns None on timeout)."""
-    if sock is None or reader is None:
-        return None
-
-    # Save original socket timeout and set temporary timeout
+def _parse_response(raw: str, method: str = "") -> dict:
+    """Parse a server response line with JSON-RPC 2.0 compliance warnings."""
     try:
-        orig = sock.gettimeout()
-    except Exception:
-        orig = None
-
-    try:
-        sock.settimeout(timeout)
-        line = reader.readline()
-        if not line:
-            return None
-        return line.rstrip('\n')
-    except Exception:
-        return None
-    finally:
-        try:
-            sock.settimeout(orig)
-        except Exception:
-            pass
-
-
-def read_notification(timeout: float = 5.0):
-    """Attempt to read a single JSON notification from the socket within timeout seconds.
-
-    Returns parsed JSON object or None on timeout/unparseable data.
-    """
-    raw = _read_raw_line(timeout)
-    if not raw:
-        return None
-
-    # Optionally print raw
-    if os.getenv("ELECTRUM_DEBUG"):
-        print("<<< notify-raw:", raw, flush=True)
-
-    try:
-        obj = json.loads(raw)
-    except Exception:
-        return None
-
-    return obj
-
-
-def parse_response(raw_data: str) -> dict:
-    """
-    Parse server response and warn if not clean JSON-RPC 2.0.
-
-    Args:
-        raw_data: Raw response string
-
-    Returns:
-        Parsed JSON object
-
-    Raises:
-        pytest.fail: If JSON is invalid
-    """
-    try:
-        resp = json.loads(raw_data)
-    except json.JSONDecodeError as e:
-        pytest.fail(f"Invalid JSON from server: {raw_data!r} → {e}")
+        resp = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"Invalid JSON from server for {method!r}: {raw!r} — {exc}")
 
     if isinstance(resp, dict):
-        if "jsonrpc" not in resp or resp["jsonrpc"] != "2.0":
+        if resp.get("jsonrpc") != "2.0":
             warnings.warn(
-                f"Server response not JSON-RPC 2.0 compliant\n"
-                f"Raw response: {raw_data}\n",
+                f"Response not JSON-RPC 2.0 (jsonrpc={resp.get('jsonrpc')!r})\n"
+                f"Raw: {raw}",
                 UserWarning,
-                stacklevel=3
+                stacklevel=3,
             )
-
         if "id" not in resp:
-            warnings.warn("Response id missing, not JSON-RPC 2.0 compliant", UserWarning)
-
-        if "result" in resp and "error" in resp:
-            warnings.warn("Contains both result and error fields, not JSON-RPC 2.0 compliant", UserWarning)
+            warnings.warn("Response missing 'id' field", UserWarning, stacklevel=3)
+        if "result" in resp and "error" in resp and resp["error"] is not None:
+            warnings.warn("Response has both 'result' and 'error'", UserWarning, stacklevel=3)
 
     return resp
 
@@ -200,251 +292,260 @@ def parse_response(raw_data: str) -> dict:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 def test_server_version():
-    """Test server.version - server identification"""
-    result = send_rpc("server.version", ["Sparrow", ["1.4", "1.6"]])
-    assert isinstance(result, list)
-    assert len(result) >= 2
-    assert isinstance(result[1], str)
-    assert result[1] >= "1.4", f"Protocol too old: {result[1]}"
+    """
+    Verify the server.version handshake result.
+
+    The handshake is performed once during session setup (persistent_connection
+    fixture) using the protocol range from --electrum-protocol. In Electrum
+    v1.4+ server.version must be the first message, so we validate the stored
+    result here rather than sending a second handshake.
+
+    Expected result: [server_name, negotiated_version]
+    The negotiated version must fall within the range offered by the client.
+    """
+    assert negotiated_version is not None, (
+        "server.version handshake failed during session setup. "
+        "Check that the server is reachable and speaks the Electrum protocol."
+    )
+    assert isinstance(negotiated_version, str)
+    assert _server_name is not None and len(_server_name) > 0, \
+        "Server did not return a name in the version handshake"
+
+    proto_min, proto_max = _configured_protocol[0], _configured_protocol[1]
+    assert negotiated_version >= proto_min, (
+        f"Server negotiated {negotiated_version!r}, below our offered minimum {proto_min!r}"
+    )
+    assert negotiated_version <= proto_max, (
+        f"Server negotiated {negotiated_version!r}, above our offered maximum {proto_max!r}"
+    )
 
 
 def test_server_banner():
-    """Test server.banner - server banner/motd"""
+    """Test server.banner — returns a human-readable server description string."""
     result = send_rpc("server.banner")
-    assert isinstance(result, str), "server.banner should return a string"
+    assert isinstance(result, str), f"server.banner must return a string, got {type(result)}"
 
 
 def test_server_features():
-    """Test server.features - server capabilities"""
+    """Test server.features — returns server capabilities and connection details."""
     result = send_rpc("server.features")
     assert isinstance(result, dict)
-    required_fields = {"genesis_hash", "hash_function", "protocol_min", "protocol_max"}
-    assert required_fields <= set(result), f"Missing required fields: {required_fields - set(result)}"
+    required = {"genesis_hash", "hash_function", "protocol_min", "protocol_max"}
+    missing = required - set(result)
+    assert not missing, f"server.features missing required fields: {missing}"
+    # Validate genesis hash format (64-char hex)
+    assert isinstance(result["genesis_hash"], str) and len(result["genesis_hash"]) == 64
 
 
 def test_server_ping():
-    """Test server.ping - connection keep-alive"""
+    """Test server.ping — keep-alive, must return null."""
     result = send_rpc("server.ping")
-    assert result is None, "server.ping should return null"
+    assert result is None, f"server.ping must return null, got {result!r}"
 
 
 def test_server_add_peer():
-    """Test server.add_peer - add a peer to the server's peer list"""
+    """Test server.add_peer — add peer to server's peer list (returns bool)."""
     features = {
-        "genesis_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        "genesis_hash": ReferenceData.GENESIS_HASH,
         "hosts": {},
         "protocol_max": "1.4",
         "protocol_min": "1.4",
-        "server_version": "test/1.0"
+        "server_version": "test/1.0",
     }
     result = send_rpc("server.add_peer", [features])
     assert isinstance(result, bool)
 
 
 def test_server_donation_address():
-    """Test server.donation_address - get server's donation address"""
+    """Test server.donation_address — optional donation address or null."""
     result = send_rpc("server.donation_address")
     assert result is None or isinstance(result, str)
 
 
 def test_server_peers_subscribe():
-    """Test server.peers.subscribe - get list of peer servers"""
+    """Test server.peers.subscribe — returns list of known peer servers."""
     result = send_rpc("server.peers.subscribe")
     assert isinstance(result, list)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# BLOCKCHAIN METHODS
+# BLOCKCHAIN — BLOCK HEADER/S
 # ═══════════════════════════════════════════════════════════════════════════════
 
 def test_blockchain_block_header():
-    """Test blockchain.block.header - get block header"""
-    # cp_height=0 means no checkpoint
-    response = send_rpc("blockchain.block.header", [ReferenceData.KNOWN_HEIGHT, 0])
+    """
+    Test blockchain.block.header with cp_height=0.
 
-    # Standard Electrum protocol: plain hex string
-    if isinstance(response, str):
-        assert len(response) == 160, f"Expected 160 hex chars, got {len(response)}"
-    # libbitcoin-server returns headers-style dict
-    elif isinstance(response, dict):
-        header_data = response.get("hex") or response.get("headers")
-        assert header_data is not None, "Expected 'hex' or 'headers' key in response"
-        if isinstance(header_data, list):
-            assert len(header_data) >= 1
-            assert len(header_data[0]) == 160
-        else:
-            assert len(header_data) == 160
-    else:
-        pytest.fail(f"Unexpected response type: {type(response)}")
+    Per the Electrum protocol spec: when cp_height is 0 (no checkpoint proof),
+    the result MUST be a plain hex string representing the serialized 80-byte
+    block header (160 hex characters).
+    """
+    response = send_rpc("blockchain.block.header", [ReferenceData.KNOWN_HEIGHT, 0])
+    assert isinstance(response, str), (
+        f"blockchain.block.header with cp_height=0 must return a plain hex string, "
+        f"got {type(response).__name__}: {response!r}"
+    )
+    assert len(response) == 160, (
+        f"Header hex must be 160 chars (80 bytes), got {len(response)}"
+    )
 
 
 def test_blockchain_block_header_with_cp():
-    """Test blockchain.block.header with cp_height - request a checkpointed proof"""
-    # Request header with checkpoint equal to the target height (produce proof)
-    response = send_rpc("blockchain.block.header", [ReferenceData.KNOWN_HEIGHT, ReferenceData.KNOWN_HEIGHT])
+    """
+    Test blockchain.block.header with cp_height > 0.
 
-    # If server returns legacy plain hex string, mark as xfail since proof isn't provided
-    if isinstance(response, str):
-        pytest.xfail("Server returned legacy header string; checkpoint proofs not provided")
+    Per spec: when a checkpoint is requested, the result is a dict with:
+      - 'header': the requested header as a hex string (160 chars)
+      - 'branch': list of hex-encoded 32-byte merkle proof hashes
+      - 'root': hex-encoded 32-byte merkle root
+    """
+    response = send_rpc(
+        "blockchain.block.header",
+        [ReferenceData.KNOWN_HEIGHT, ReferenceData.KNOWN_HEIGHT],
+    )
 
-    # Expect dict-style response containing header and proof fields
-    assert isinstance(response, dict)
-    header_data = response.get("hex") or response.get("headers")
-    assert header_data is not None, "Expected 'hex' or 'headers' key in response"
+    assert isinstance(response, dict), (
+        f"blockchain.block.header with cp_height > 0 must return a dict, "
+        f"got {type(response).__name__}. "
+        f"Keys present: {list(response.keys()) if isinstance(response, dict) else 'n/a'}"
+    )
 
-    # Validate header content as in non-checkpoint test
-    if isinstance(header_data, list):
-        assert len(header_data) >= 1
-        assert len(header_data[0]) == 160
-    else:
-        assert len(header_data) == 160
-
-    # Check that merkle proof info is present when checkpoint requested
+    # Per spec the singular header is under the key 'header' (not 'hex' / 'headers')
+    assert "header" in response, (
+        f"Expected 'header' key in checkpoint response, got keys: {list(response.keys())}"
+    )
+    assert isinstance(response["header"], str) and len(response["header"]) == 160, (
+        f"'header' must be a 160-char hex string, got: {response['header']!r}"
+    )
     assert "root" in response, "Expected 'root' in checkpointed response"
     assert "branch" in response, "Expected 'branch' in checkpointed response"
     assert isinstance(response["branch"], list)
-    # Validate branch element formats (hex digests)
     for h in response["branch"]:
-        assert isinstance(h, str) and len(h) == 64
+        assert isinstance(h, str) and len(h) == 64, \
+            f"Each branch element must be a 64-char hex hash, got {h!r}"
 
 
 def test_blockchain_block_header_with_cp_protocol_example():
-    """Test blockchain.block.header with cp_height using the example from the Electrum protocol docs.
+    """
+    Test blockchain.block.header with the exact example from the Electrum protocol docs.
 
     https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-block-header
+    Parameters: height=5, cp_height=8
     """
-    # Parameters taken verbatim from the protocol spec example: height=5, cp_height=8
     response = send_rpc("blockchain.block.header", [5, 8])
 
-    # If server returns legacy plain hex string, mark as xfail since proof isn't provided
-    if isinstance(response, str):
-        pytest.xfail("Server returned legacy header string; checkpoint proofs not provided")
-
-    # Expect dict-style response containing header and proof fields
-    assert isinstance(response, dict)
-    header_data = response.get("hex") or response.get("headers")
-    assert header_data is not None, "Expected 'hex' or 'headers' key in response"
-
-    # Validate header content as in non-checkpoint test
-    if isinstance(header_data, list):
-        assert len(header_data) >= 1
-        assert len(header_data[0]) == 160
-    else:
-        assert len(header_data) == 160
-
-    # Check that merkle proof info is present when checkpoint requested
-    assert "root" in response, "Expected 'root' in checkpointed response"
-    assert "branch" in response, "Expected 'branch' in checkpointed response"
+    assert isinstance(response, dict), (
+        f"blockchain.block.header with cp_height=8 must return a dict, "
+        f"got {type(response).__name__}"
+    )
+    assert "header" in response, (
+        f"Expected 'header' key per spec, got keys: {list(response.keys())}"
+    )
+    assert isinstance(response["header"], str) and len(response["header"]) == 160
+    assert "root" in response
+    assert "branch" in response
     assert isinstance(response["branch"], list)
-    # Validate branch element formats (hex digests)
     for h in response["branch"]:
         assert isinstance(h, str) and len(h) == 64
 
 
 def test_blockchain_block_headers():
-    """Test blockchain.block.headers - get multiple block headers"""
-    # Get 5 headers starting from KNOWN_HEIGHT
+    """
+    Test blockchain.block.headers — fetch multiple block headers, no checkpoint.
+
+    Per spec, result is a dict with:
+      - 'count': number of headers returned
+      - 'hex' (< v1.6): concatenated hex string, length = count * 160
+      - 'headers' (v1.6+): array of individual header hex strings
+      - 'max': maximum headers the server returns per request
+    """
     result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT, 5, 0])
     assert isinstance(result, dict)
-    assert "count" in result
+    assert "count" in result, f"Response missing 'count': {result}"
 
-    # Accept either format
-    header_data = result.get("hex") or result.get("headers")
-    assert header_data is not None, "Expected 'hex' or 'headers' key in response"
-    assert isinstance(header_data, str) or isinstance(header_data, list)
+    header_data = result.get("headers") or result.get("hex")
+    assert header_data is not None, (
+        f"Expected 'headers' (v1.6+) or 'hex' (pre-v1.6) key, got keys: {list(result.keys())}"
+    )
 
-    # Validate content
     if isinstance(header_data, list):
         assert len(header_data) == result["count"]
-        assert all(isinstance(h, str) and len(h) == 160 for h in header_data)
+        assert all(isinstance(h, str) and len(h) == 160 for h in header_data), \
+            "Each header must be 160-char hex"
     else:
-        # Old style single string
-        assert len(header_data) == 160 * result["count"]
+        assert isinstance(header_data, str)
+        assert len(header_data) == 160 * result["count"], (
+            f"Concatenated hex length mismatch: expected {160 * result['count']}, "
+            f"got {len(header_data)}"
+        )
 
 
 def test_blockchain_block_headers_protocol_example():
-    """Test blockchain.block.headers using the example from the Electrum protocol docs.
+    """
+    Test blockchain.block.headers using the example from the Electrum protocol docs.
 
     https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-block-headers
+    Parameters: start_height=5, count=8, cp_height=0
     """
-    # Parameters taken verbatim from the protocol spec example: start_height=5, count=8, cp_height=0
     result = send_rpc("blockchain.block.headers", [5, 8, 0])
     assert isinstance(result, dict)
     assert "count" in result
 
-    # Accept either format
-    header_data = result.get("hex") or result.get("headers")
-    assert header_data is not None, "Expected 'hex' or 'headers' key in response"
-    assert isinstance(header_data, str) or isinstance(header_data, list)
+    header_data = result.get("headers") or result.get("hex")
+    assert header_data is not None, \
+        f"Expected 'headers' or 'hex' key, got: {list(result.keys())}"
 
-    # Validate content
     if isinstance(header_data, list):
         assert len(header_data) == result["count"]
         assert all(isinstance(h, str) and len(h) == 160 for h in header_data)
     else:
-        # Old style single string
         assert len(header_data) == 160 * result["count"]
 
 
 def test_blockchain_block_headers_with_cp_single():
-    """Request a small batch with checkpoint proof and validate proof fields."""
-    # Request 1 header with a checkpoint at a later height to trigger proof.
+    """
+    Request a single block header with a checkpoint proof and validate all fields.
+
+    Per spec: when cp_height is provided, result additionally contains
+    'branch' and 'root' fields.
+    """
     cp = ReferenceData.KNOWN_HEIGHT + 10
-    try:
-        result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT, 1, cp])
-    except Exception as e:
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg:
-            pytest.skip(f"Server does not support checkpointed headers: {e}")
-        raise
+    result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT, 1, cp])
 
     assert isinstance(result, dict)
-    # Headers present
     header_data = result.get("headers") or result.get("hex")
-    assert header_data is not None
-    # Proof fields should be present when cp requested
-    assert "root" in result and "branch" in result
+    assert header_data is not None, \
+        f"Expected 'headers' or 'hex' key, got: {list(result.keys())}"
+    assert "root" in result and "branch" in result, \
+        "Checkpoint response must include 'root' and 'branch'"
     assert isinstance(result["branch"], list)
+    for h in result["branch"]:
+        assert isinstance(h, str) and len(h) == 64
 
 
 def test_blockchain_block_headers_with_cp_multiple():
-    """Request multiple headers with checkpoint proof (cp_height >= target)."""
+    """Request multiple headers with a checkpoint proof."""
     count = 5
-    cp = ReferenceData.KNOWN_HEIGHT + 20  # cp must be >= start + (count - 1)
-    try:
-        result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT, count, cp])
-    except Exception as e:
-        msg = str(e).lower()
-        if "target_overflow" in msg or "not_implemented" in msg or "not_found" in msg:
-            pytest.skip(f"Server did not provide multi-header checkpoint proof: {e}")
-        raise
+    cp = ReferenceData.KNOWN_HEIGHT + 20
+    result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT, count, cp])
 
     assert isinstance(result, dict)
     header_data = result.get("headers") or result.get("hex")
     assert header_data is not None
-    # Validate multiple headers format
+
     if isinstance(header_data, list):
         assert len(header_data) == result["count"]
     else:
         assert len(header_data) == 160 * result["count"]
 
-    # Proof should be returned
     assert "root" in result and "branch" in result
     assert isinstance(result["branch"], list)
 
 
 def test_blockchain_block_headers_height_900000_with_cp():
-    """Request headers at height 900000 with checkpoint proof."""
-    start = 900000
-    count = 1
-    cp = 900010
-    try:
-        result = send_rpc("blockchain.block.headers", [start, count, cp])
-    except Exception as e:
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg:
-            pytest.skip(f"Server does not support checkpointed headers at height {start}: {e}")
-        raise
+    """Request headers at height 900,000 with a checkpoint proof."""
+    start, count, cp = 900000, 1, 900010
+    result = send_rpc("blockchain.block.headers", [start, count, cp])
 
     assert isinstance(result, dict)
     header_data = result.get("headers") or result.get("hex")
@@ -455,215 +556,202 @@ def test_blockchain_block_headers_height_900000_with_cp():
     else:
         assert len(header_data) == 160 * result["count"]
     assert "root" in result and "branch" in result
-    assert isinstance(result["branch"], list)
     for h in result["branch"]:
         assert isinstance(h, str) and len(h) == 64
 
 
 def test_blockchain_block_headers_20000_at_tip_with_cp():
-    """Request 20000 headers at a fixed well-confirmed range with checkpoint proof."""
-    start = 900000
-    count = 20000
-    cp = start + count - 1  # = 919999, well below current tip
+    """
+    Request 20,000 headers at a well-confirmed range with a checkpoint proof.
 
-    try:
-        result = send_rpc("blockchain.block.headers", [start, count, cp])
-    except Exception as e:
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg or "target_overflow" in msg:
-            pytest.skip(f"Server does not support 20000 checkpointed headers: {e}")
-        raise
+    The server may return fewer headers than requested — servers impose their
+    own per-request maximum (e.g. ElectrumX defaults to 2016, one retarget
+    period; libbitcoin-server can be configured up to 20160). The test verifies
+    the response is valid and internally consistent, not a specific count.
+    """
+    start, count = 900000, 20000
+    cp = start + count - 1  # = 919999, well below current tip
+    result = send_rpc("blockchain.block.headers", [start, count, cp])
 
     assert isinstance(result, dict)
     header_data = result.get("headers") or result.get("hex")
     assert header_data is not None
+    returned = result["count"]
+    assert 0 < returned <= count, \
+        f"Returned {returned} headers, expected 1–{count}"
     if isinstance(header_data, list):
-        assert len(header_data) == result["count"]
+        assert len(header_data) == returned
         assert all(isinstance(h, str) and len(h) == 160 for h in header_data)
     else:
-        assert len(header_data) == 160 * result["count"]
-    assert result["count"] == count
+        assert len(header_data) == 160 * returned
     assert "root" in result and "branch" in result
-    assert isinstance(result["branch"], list)
     for h in result["branch"]:
         assert isinstance(h, str) and len(h) == 64
 
 
 def test_blockchain_block_headers_max_at_tip_with_cp():
-    """Request maximum headers (20160) ending at the current chain tip with checkpoint proof."""
+    """
+    Request as many headers as possible ending at the current chain tip.
+
+    Uses count=20160 (max in the Electrum spec). The server will cap the
+    actual returned count at its own configured maximum. The test verifies
+    that the response is valid and the proof fields are consistent with the
+    actual returned range — not that a specific count was returned.
+    """
     count = 20160
 
-    # Get current chain tip
-    try:
-        tip = send_rpc("blockchain.headers.subscribe")
-    except Exception as e:
-        pytest.skip(f"Could not get chain tip: {e}")
-
-    tip_height = tip.get("height") if isinstance(tip, dict) else None
+    tip = send_rpc("blockchain.headers.subscribe")
+    # height key differs by version: 'height' (v1.3+) or 'block_height' (v1.0-v1.2)
+    tip_height = (
+        tip.get("height") or tip.get("block_height")
+        if isinstance(tip, dict) else None
+    )
     if tip_height is None:
         pytest.skip("blockchain.headers.subscribe did not return height")
 
     start = tip_height - count + 1
     cp = tip_height
 
-    try:
-        result = send_rpc("blockchain.block.headers", [start, count, cp])
-    except Exception as e:
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg or "target_overflow" in msg:
-            pytest.skip(f"Server does not support max checkpointed headers: {e}")
-        raise
+    result = send_rpc("blockchain.block.headers", [start, count, cp])
 
     assert isinstance(result, dict)
     header_data = result.get("headers") or result.get("hex")
     assert header_data is not None
+    returned = result["count"]
+    assert 0 < returned <= count, \
+        f"Returned {returned} headers, expected 1–{count}"
     if isinstance(header_data, list):
-        assert len(header_data) == result["count"]
+        assert len(header_data) == returned
         assert all(isinstance(h, str) and len(h) == 160 for h in header_data)
     else:
-        assert len(header_data) == 160 * result["count"]
-    assert result["count"] == count
+        assert len(header_data) == 160 * returned
     assert "root" in result and "branch" in result
-    assert isinstance(result["branch"], list)
     for h in result["branch"]:
         assert isinstance(h, str) and len(h) == 64
 
 
 def test_blockchain_block_headers_count_zero():
-    """Request zero headers (count=0) and validate empty response handling."""
-    try:
-        result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT + 1000000, 0, 0])
-    except Exception as e:
-        # If server treats out-of-range as not_found, skip
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg:
-            pytest.skip(f"Server cannot handle count=0 for out-of-range start: {e}")
-        raise
-
+    """
+    Request zero headers — server must return an empty/zero response.
+    Sending count=0 with an out-of-range start is an edge case;
+    xfail on not_found is acceptable.
+    """
+    result = send_rpc("blockchain.block.headers", [ReferenceData.KNOWN_HEIGHT + 1000000, 0, 0])
     assert isinstance(result, dict)
     assert "count" in result
-    assert result["count"] == 0 or (result.get("headers") == [] or result.get("hex") in ("", None))
+    assert result["count"] == 0 or result.get("headers") in ([], None) or result.get("hex") in ("", None)
 
 
 def test_blockchain_block_headers_cp_target_overflow():
-    """Request headers with cp_height < target and expect an error (xfail)."""
-    # Choose cp smaller than target to trigger target_overflow on server.
+    """
+    Request headers where cp_height < target height — server must respond with an error.
+    (target = start + count - 1, so here target = KNOWN_HEIGHT + 4 > cp = KNOWN_HEIGHT)
+    """
     start = ReferenceData.KNOWN_HEIGHT
     count = 5
-    cp = start  # target = start + (count - 1) > cp
-
-    # send_rpc will call pytest.xfail for server errors; calling it directly is fine.
+    cp = start  # target overflows cp
+    # send_rpc converts server errors to pytest.xfail automatically
     send_rpc("blockchain.block.headers", [start, count, cp])
 
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# BLOCKCHAIN — HEADERS SUBSCRIBE
+# ═══════════════════════════════════════════════════════════════════════════════
+
 def test_blockchain_headers_subscribe():
-    """Test blockchain.headers.subscribe - subscribe to block header notifications"""
-    try:
-        result = send_rpc("blockchain.headers.subscribe")
-    except Exception as e:
-        # The server may return 'not_found' (race) or 'not_implemented'; treat
-        # these as acceptable and skip the test rather than failing.
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg or "not implemented" in msg:
-            pytest.skip(f"Server response not available: {e}")
-        raise
-
-    assert isinstance(result, dict)
-    assert "height" in result
-    assert "hex" in result
-    assert len(result["hex"]) == 160  # 80 bytes hex
-
-
-def test_blockchain_headers_notification():
-    """Subscribe to headers and wait for a notification.
-
-    Optional trigger: set `ELECTRUM_TRIGGER_HEADERS` to a shell command that
-    will cause the node to produce a new block (or otherwise send a header
-    notification). If not provided, the test will wait for a short interval
-    and skip if no notification arrives.
     """
-    try:
-        initial = send_rpc("blockchain.headers.subscribe")
-    except Exception as e:
-        msg = str(e).lower()
-        if "not_found" in msg or "not_implemented" in msg:
-            pytest.skip(f"Server subscription not available: {e}")
-        raise
+    Test blockchain.headers.subscribe — subscribe to block header notifications.
 
-    # Optionally trigger an external action to cause a header notification.
-    cmd = os.getenv("ELECTRUM_TRIGGER_HEADERS")
-    if cmd:
-        subprocess.run(cmd, shell=True)
+    The response format is version-dependent:
 
-    notif = read_notification(timeout=10.0)
-    if notif is None:
-        pytest.skip("No header notification received within timeout")
+    v1.0–v1.2  (raw=false default): deserialized header object
+      {'block_height': int, 'version': int, 'prev_block_hash': str, ...}
 
-    # Notification may be either a JSON-RPC notification {'method', 'params'}
-    # or a direct header object. Accept both.
-    if isinstance(notif, dict):
-        if "method" in notif and isinstance(notif.get("params"), list):
-            params = notif["params"]
-            if params and isinstance(params[0], dict):
-                payload = params[0]
-                assert "height" in payload and "hex" in payload
-                assert len(payload["hex"]) == 160
-                return
-        if "height" in notif and "hex" in notif:
-            assert len(notif["hex"]) == 160
-            return
+    v1.3+      (raw=true default / forced): serialized raw format
+      {'height': int, 'hex': str (160 chars)}
 
-    pytest.skip("Unrecognized header notification format")
+    v1.4+: the 'raw' parameter is removed; always raw format.
 
-
-def test_blockchain_scripthash_subscribe_notification():
-    """Subscribe to an example scripthash and wait for a notification.
-
-    Optional trigger: set `ELECTRUM_TRIGGER_SCRIPTHASH` to a shell command
-    which will broadcast or otherwise create activity for `EXAMPLE_SCRIPTHASH`.
+    Push notifications after subscribing are tested separately in
+    test_electrum_subscriptions.py. The send_rpc helper transparently
+    skips any notifications on the shared session connection.
     """
-    try:
-        result = send_rpc("blockchain.scripthash.subscribe", [ReferenceData.EXAMPLE_SCRIPTHASH])
-    except Exception as e:
-        msg = str(e).lower()
-        if "not_implemented" in msg or "unknown method" in msg:
-            pytest.skip(f"scripthash.subscribe not supported: {e}")
-        raise
+    result = send_rpc("blockchain.headers.subscribe")
 
-    # Optional trigger to produce a mempool or confirmation event
-    cmd = os.getenv("ELECTRUM_TRIGGER_SCRIPTHASH")
-    if cmd:
-        subprocess.run(cmd, shell=True)
+    assert isinstance(result, dict), \
+        f"blockchain.headers.subscribe must return a dict, got {type(result)}"
 
-    notif = read_notification(timeout=10.0)
-    if notif is None:
-        pytest.skip("No scripthash notification received within timeout")
+    if negotiated_version is not None and negotiated_version >= "1.3":
+        # v1.3+: raw serialized format — height + hex
+        assert "height" in result, (
+            f"v1.3+ response must have 'height', got keys: {list(result.keys())}"
+        )
+        assert "hex" in result, (
+            f"v1.3+ response must have 'hex', got keys: {list(result.keys())}"
+        )
+        assert isinstance(result["height"], int) and result["height"] >= 0
+        assert isinstance(result["hex"], str) and len(result["hex"]) == 160, (
+            f"'hex' must be 160-char header, got length {len(result.get('hex', ''))}"
+        )
+    else:
+        # v1.0–v1.2: deserialized header object with block_height
+        assert "block_height" in result, (
+            f"v1.0–1.2 response must have 'block_height', got keys: {list(result.keys())}"
+        )
+        assert isinstance(result["block_height"], int) and result["block_height"] >= 0
+        # Must contain raw header fields (not a serialized blob)
+        assert any(k in result for k in ("version", "prev_block_hash", "merkle_root")), (
+            f"v1.0–1.2 response missing expected header fields: {list(result.keys())}"
+        )
 
-    # Notification commonly comes as JSON-RPC method with params [scripthash, status]
-    if isinstance(notif, dict) and notif.get("method") and isinstance(notif.get("params"), list):
-        params = notif["params"]
-        # params may be [scripthash, status] or [status]
-        assert isinstance(params, list)
-        # basic validation
-        assert len(params) >= 1
-        return
 
-    pytest.skip("Unrecognized scripthash notification format")
-
+# ═══════════════════════════════════════════════════════════════════════════════
+# BLOCKCHAIN — FEE ESTIMATION
+# ═══════════════════════════════════════════════════════════════════════════════
 
 def test_blockchain_estimatefee():
-    """Test blockchain.estimatefee - estimate transaction fee"""
-    # Estimate fee for confirmation in 25 blocks
+    """
+    Test blockchain.estimatefee — returns estimated fee rate in BTC/kB.
+
+    Per spec, the server may return -1 if fee estimation is unavailable
+    (e.g. mempool data not indexed or insufficient samples). Any positive
+    value is a fee rate. Both are valid protocol responses.
+    """
     result = send_rpc("blockchain.estimatefee", [25])
-    assert isinstance(result, (float, int))
-    assert result >= 0
+    assert isinstance(result, (float, int)), \
+        f"blockchain.estimatefee must return a number, got {type(result)}"
+    # -1 is the protocol-defined "unavailable" sentinel; any positive value is a fee rate
+    assert result == -1 or result > 0, \
+        f"Expected positive fee rate or -1 (unavailable), got {result}"
 
 
 def test_blockchain_relayfee():
-    """Test blockchain.relayfee - minimum relay fee"""
+    """
+    Test blockchain.relayfee — minimum relay fee rate in BTC/kB.
+
+    Available in v1.0–v1.4.2 only. Removed in v1.6; clients should use
+    server.features['fee_rate'] instead. When negotiated version is v1.6+,
+    the server must reject the call with wrong_version.
+    """
+    if negotiated_version is not None and negotiated_version >= "1.6":
+        # v1.6+: the method was removed. The server must reject it with any
+        # error response — libbitcoin-server returns 'wrong_version', ElectrumX
+        # returns -32601 'unknown method'. Both are correct; we just verify it fails.
+        try:
+            _rpc_raw("blockchain.relayfee")
+            pytest.fail(
+                "blockchain.relayfee should fail in v1.6+ (method removed), "
+                "but the server returned a result"
+            )
+        except ValueError:
+            pass  # Any error response is correct — method no longer exists in v1.6
+        return
+
+    # v1.0–v1.4.2: must return a positive fee rate in BTC/kB.
     result = send_rpc("blockchain.relayfee")
-    assert isinstance(result, float)
-    assert result > 0, "Relay fee should be positive"
+    assert isinstance(result, (float, int)), \
+        f"blockchain.relayfee must return a number, got {type(result)}"
+    assert result > 0, f"Relay fee must be positive, got {result}"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -671,47 +759,46 @@ def test_blockchain_relayfee():
 # ═══════════════════════════════════════════════════════════════════════════════
 
 def test_blockchain_scripthash_get_balance():
-    """Test blockchain.scripthash.get_balance - get address balance"""
+    """
+    Test blockchain.scripthash.get_balance — returns confirmed/unconfirmed satoshi balance.
+
+    Result: {'confirmed': int, 'unconfirmed': int}
+    """
     result = send_rpc("blockchain.scripthash.get_balance", [ReferenceData.EXAMPLE_SCRIPTHASH])
-    assert isinstance(result, dict)
-    assert "confirmed" in result
-    assert "unconfirmed" in result
-    assert isinstance(result["confirmed"], int)
+    assert isinstance(result, dict), f"Expected dict, got {type(result)}"
+    assert "confirmed" in result and "unconfirmed" in result, \
+        f"Missing required keys in balance response: {result}"
+    assert isinstance(result["confirmed"], int) and result["confirmed"] >= 0
     assert isinstance(result["unconfirmed"], int)
-    assert result["confirmed"] >= 0
-    assert result["unconfirmed"] >= 0
 
 
 def test_blockchain_scripthash_get_history():
-    """Test blockchain.scripthash.get_history - get address transaction history"""
+    """
+    Test blockchain.scripthash.get_history — returns list of transaction entries.
+
+    Each entry: {'tx_hash': str, 'height': int}
+    Mempool entries may additionally include 'fee'.
+    """
     result = send_rpc("blockchain.scripthash.get_history", [ReferenceData.EXAMPLE_SCRIPTHASH])
-    assert isinstance(result, list)
+    assert isinstance(result, list), f"Expected list, got {type(result)}"
     for entry in result:
         assert isinstance(entry, dict)
-        assert "tx_hash" in entry
-        assert "height" in entry
+        assert "tx_hash" in entry, f"History entry missing 'tx_hash': {entry}"
+        assert "height" in entry, f"History entry missing 'height': {entry}"
+        assert isinstance(entry["tx_hash"], str) and len(entry["tx_hash"]) == 64
+        assert isinstance(entry["height"], int)
 
 
 def test_blockchain_scripthash_get_mempool():
-    """Test blockchain.scripthash.get_mempool - get unconfirmed transactions"""
-    try:
-        response = send_rpc("blockchain.scripthash.get_mempool", [ReferenceData.EXAMPLE_SCRIPTHASH])
-    except RuntimeError as e:
-        if "No such mempool transaction" in str(e) and "-txindex" in str(e):
-            pytest.xfail("txindex missing → getrawtransaction fails as expected")
-        else:
-            raise
+    """
+    Test blockchain.scripthash.get_mempool — unconfirmed transactions for scripthash.
 
-    # Handle different response formats
-    if isinstance(response, list):
-        mempool = response
-    else:
-        # Normal JSON-RPC style
-        assert "error" not in response or response["error"] is None
-        assert "result" in response
-        mempool = response["result"]
-
-    for entry in mempool:
+    Each entry: {'tx_hash': str, 'height': int, 'fee': int}
+    height is 0 for unconfirmed, -1 for unconfirmed with unconfirmed ancestors.
+    """
+    result = send_rpc("blockchain.scripthash.get_mempool", [ReferenceData.EXAMPLE_SCRIPTHASH])
+    assert isinstance(result, list), f"Expected list, got {type(result)}"
+    for entry in result:
         assert isinstance(entry, dict)
         assert "tx_hash" in entry
         assert "height" in entry
@@ -719,41 +806,55 @@ def test_blockchain_scripthash_get_mempool():
 
 
 def test_blockchain_scripthash_list_unspent():
-    """Test blockchain.scripthash.list_unspent - list unspent outputs"""
-    result = send_rpc("blockchain.scripthash.list_unspent", [ReferenceData.EXAMPLE_SCRIPTHASH])
-    assert isinstance(result, list)
+    """
+    Test blockchain.scripthash.listunspent — UTXO list for scripthash.
+
+    Note: the Electrum protocol uses 'listunspent' (no underscore before 'unspent'),
+    unlike get_balance / get_history which use underscores.
+
+    Each entry: {'tx_hash': str, 'tx_pos': int, 'value': int, 'height': int}
+    """
+    result = send_rpc("blockchain.scripthash.listunspent", [ReferenceData.EXAMPLE_SCRIPTHASH])
+    assert isinstance(result, list), f"Expected list, got {type(result)}"
     for utxo in result:
         assert isinstance(utxo, dict)
-        assert "tx_hash" in utxo
-        assert "tx_pos" in utxo
-        assert "value" in utxo
-        assert "height" in utxo
+        for key in ("tx_hash", "tx_pos", "value", "height"):
+            assert key in utxo, f"UTXO missing '{key}': {utxo}"
+        assert isinstance(utxo["tx_hash"], str) and len(utxo["tx_hash"]) == 64
+        assert isinstance(utxo["tx_pos"], int) and utxo["tx_pos"] >= 0
+        assert isinstance(utxo["value"], int) and utxo["value"] >= 0
+        assert isinstance(utxo["height"], int)
 
 
 def test_blockchain_scripthash_subscribe():
-    """Test blockchain.scripthash.subscribe - subscribe to address changes"""
+    """
+    Test blockchain.scripthash.subscribe — initial response only.
+
+    Returns null if the scripthash has no history, otherwise a 64-char hex
+    status hash (SHA256 of the canonical history string, natural byte order).
+
+    Push notifications for subsequent status changes are tested in
+    test_electrum_subscriptions.py. The send_rpc helper skips any notifications
+    that arrive on the shared connection while later tests run.
+    """
     result = send_rpc("blockchain.scripthash.subscribe", [ReferenceData.EXAMPLE_SCRIPTHASH])
-    # Subscription response is usually None (confirmation via notification)
-    assert result is None or isinstance(result, str)
+    assert result is None or (isinstance(result, str) and len(result) == 64), (
+        f"blockchain.scripthash.subscribe must return null or a 64-char status hash, "
+        f"got {result!r}"
+    )
 
 
 def test_blockchain_scripthash_unsubscribe():
-    """Test blockchain.scripthash.unsubscribe - unsubscribe from address"""
-    try:
-        response = send_rpc("blockchain.scripthash.unsubscribe", [ReferenceData.EXAMPLE_SCRIPTHASH])
+    """
+    Test blockchain.scripthash.unsubscribe — cancels a scripthash subscription.
 
-        # Successful responses are usually True, False, None, empty dict/list
-        assert response in (True, False, None, {}, [])
-
-    except Exception as e:
-        error_msg = str(e).lower()
-        if "unknown method" in error_msg or "unsubscribe" in error_msg:
-            pytest.skip(
-                "Server does not implement blockchain.scripthash.unsubscribe "
-                "(normal on electrs; supported on ElectrumX, Fulcrum, etc.)"
-            )
-        else:
-            pytest.xfail(f"Unexpected error in unsubscribe call: {e}")
+    Returns True if the subscription existed and was removed, False otherwise.
+    Not all server implementations support this method.
+    """
+    result = send_rpc("blockchain.scripthash.unsubscribe", [ReferenceData.EXAMPLE_SCRIPTHASH])
+    assert isinstance(result, bool), (
+        f"blockchain.scripthash.unsubscribe must return bool, got {result!r}"
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -761,52 +862,82 @@ def test_blockchain_scripthash_unsubscribe():
 # ═══════════════════════════════════════════════════════════════════════════════
 
 def test_blockchain_transaction_broadcast():
-    """Test blockchain.transaction.broadcast - broadcast a raw transaction"""
-    # Send an invalid transaction hex; server error is expected and handled as xfail
+    """
+    Test blockchain.transaction.broadcast — broadcast a raw transaction.
+
+    Sending an invalid transaction hex exercises the broadcast path.
+    The server is expected to reject it with an error (xfail).
+    """
     send_rpc("blockchain.transaction.broadcast", ["00" * 10])
 
 
 def test_blockchain_transaction_get():
-    """Test blockchain.transaction.get - get transaction (raw hex)"""
+    """
+    Test blockchain.transaction.get — returns raw transaction as hex string.
+
+    Per spec: with verbose=False (default), result is a plain hex string.
+    """
     response = send_rpc("blockchain.transaction.get", [ReferenceData.KNOWN_TX_HASH, False])
-    assert isinstance(response, str)
-    assert len(response) > 100  # Transaction should be reasonable length
+    assert isinstance(response, str), \
+        f"blockchain.transaction.get must return a hex string, got {type(response)}"
+    assert len(response) > 100, "Transaction hex seems too short"
+    # Validate it's valid hex
+    try:
+        bytes.fromhex(response)
+    except ValueError:
+        pytest.fail(f"Response is not valid hex: {response[:64]}...")
 
 
 def test_blockchain_transaction_get_verbose():
-    """Test blockchain.transaction.get with verbose=True"""
+    """
+    Test blockchain.transaction.get with verbose=True — returns decoded tx object.
+
+    Per spec, the verbose response is an object containing at least:
+      'txid', 'hex', 'confirmations', 'blockhash'
+    """
     response = send_rpc("blockchain.transaction.get", [ReferenceData.KNOWN_TX_HASH, True])
-
-    assert isinstance(response, dict)
-    assert "hex" in response
-    assert "confirmations" in response
-    assert "blockhash" in response
+    assert isinstance(response, dict), \
+        f"Verbose transaction response must be a dict, got {type(response)}"
+    for key in ("txid", "hex", "confirmations", "blockhash"):
+        assert key in response, f"Verbose tx response missing '{key}': {list(response.keys())}"
     assert response["txid"].lower() == ReferenceData.KNOWN_TX_HASH.lower()
-
-    # Validate embedded hex
-    assert isinstance(response.get("hex"), str)
-    assert len(response["hex"]) > 100
+    assert isinstance(response["hex"], str) and len(response["hex"]) > 100
 
 
 def test_blockchain_transaction_get_merkle():
-    """Test blockchain.transaction.get_merkle - get merkle proof for transaction"""
+    """
+    Test blockchain.transaction.get_merkle — returns Merkle proof for a transaction.
+
+    Result: {'block_height': int, 'merkle': [str, ...], 'pos': int}
+    """
     result = send_rpc(
         "blockchain.transaction.get_merkle",
-        [ReferenceData.KNOWN_TX_HASH, ReferenceData.KNOWN_HEIGHT]
+        [ReferenceData.KNOWN_TX_HASH, ReferenceData.KNOWN_HEIGHT],
     )
     assert isinstance(result, dict)
-    assert "merkle" in result
-    assert "pos" in result
+    assert "merkle" in result and "pos" in result, \
+        f"get_merkle response missing fields: {list(result.keys())}"
     assert isinstance(result["merkle"], list)
-    assert isinstance(result["pos"], int)
+    assert isinstance(result["pos"], int) and result["pos"] >= 0
+    for h in result["merkle"]:
+        assert isinstance(h, str) and len(h) == 64
 
 
 def test_blockchain_transaction_id_from_pos():
-    """Test blockchain.transaction.id_from_pos - get tx hash from block position"""
-    # Get coinbase (position 0) from KNOWN_HEIGHT
-    result = send_rpc("blockchain.transaction.id_from_pos", [ReferenceData.KNOWN_HEIGHT, 0, True])
-    assert isinstance(result, dict)
-    # Should contain tx_hash and potentially merkle proof
+    """
+    Test blockchain.transaction.id_from_pos — get tx hash from block position.
+
+    With merkle=True, result is a dict with 'tx_hash' and 'merkle'.
+    Position 0 is the coinbase transaction.
+    """
+    result = send_rpc(
+        "blockchain.transaction.id_from_pos",
+        [ReferenceData.KNOWN_HEIGHT, 0, True],
+    )
+    assert isinstance(result, dict), \
+        f"id_from_pos with merkle=True must return a dict, got {type(result)}"
+    assert "tx_hash" in result, f"Response missing 'tx_hash': {list(result.keys())}"
+    assert isinstance(result["tx_hash"], str) and len(result["tx_hash"]) == 64
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -814,31 +945,24 @@ def test_blockchain_transaction_id_from_pos():
 # ═══════════════════════════════════════════════════════════════════════════════
 
 def test_mempool_get_fee_histogram():
-    """Test mempool.get_fee_histogram - get fee distribution"""
+    """
+    Test mempool.get_fee_histogram — returns fee distribution histogram.
+
+    Result: [[fee_rate, cumulative_vsize], ...] sorted by fee_rate (ascending or descending).
+    An empty list [] is valid if the mempool is empty or data is unavailable.
+    """
     response = send_rpc("mempool.get_fee_histogram")
+    assert isinstance(response, list), \
+        f"mempool.get_fee_histogram must return a list, got {type(response)}"
 
-    # Handle different response formats
-    if isinstance(response, list):
-        histogram = response
-    else:
-        warnings.warn(
-            "Wrong response format for mempool.get_fee_histogram, expected naked array",
-            UserWarning
-        )
-        histogram = response
-
-    # Validate histogram structure
-    for entry in histogram:
-        assert isinstance(entry, list)
-        assert len(entry) == 2
+    for entry in response:
+        assert isinstance(entry, list) and len(entry) == 2, \
+            f"Each histogram entry must be [fee_rate, vsize], got {entry!r}"
         fee_rate, cum_vsize = entry
-        assert isinstance(fee_rate, (int, float))
-        assert isinstance(cum_vsize, (int, float))
-        assert fee_rate >= 0
-        assert cum_vsize >= 0
+        assert isinstance(fee_rate, (int, float)) and fee_rate >= 0
+        assert isinstance(cum_vsize, (int, float)) and cum_vsize >= 0
 
-    # Validate sorting (fee rates must be monotone - either ascending or descending)
-    if len(histogram) >= 2:
-        fees = [entry[0] for entry in histogram]
+    if len(response) >= 2:
+        fees = [e[0] for e in response]
         assert fees == sorted(fees) or fees == sorted(fees, reverse=True), \
-            "Fee rates should be monotonically sorted"
+            "Fee rates must be monotonically sorted (ascending or descending)"

--- a/endpoints/test_electrum_subscriptions.py
+++ b/endpoints/test_electrum_subscriptions.py
@@ -1,0 +1,296 @@
+"""
+Electrum subscription / push-notification tests.
+
+These tests subscribe to server events and wait for real blockchain push
+notifications. They require a live node with active network traffic
+(new blocks arriving or transactions being broadcast) and much longer
+timeouts than the regular request/response tests.
+
+Each test opens its own fresh TCP connection (function-scoped) so that
+subscriptions are fully isolated and don't interfere with each other or
+with the shared session connection in test_electrum.py.
+
+Run with:
+
+    pytest test_electrum_subscriptions.py
+    pytest test_electrum_subscriptions.py --subscription-timeout=120
+
+Optional environment variables:
+    ELECTRUM_TRIGGER_HEADERS    Shell command to produce a new block header event
+    ELECTRUM_TRIGGER_SCRIPTHASH Shell command to produce activity for EXAMPLE_SCRIPTHASH
+    ELECTRUM_DEBUG=1            Pretty-print all JSON-RPC messages
+"""
+
+import json
+import os
+import select
+import socket
+import subprocess
+import time
+import pytest
+from typing import Any
+
+from utils import ReferenceData, TestConfig
+
+_CLIENT_NAME = "libbitcoin-server-test/1.0"
+
+
+# ─── Connection class ─────────────────────────────────────────────────────────
+
+class ElectrumConnection:
+    """
+    Manages a single Electrum TCP connection with a manual line buffer.
+
+    Uses select() + recv() instead of socket.makefile() so that timeouts
+    on notification waits never corrupt the reader state.
+    """
+
+    def __init__(self, host: str, port: int, connect_timeout: float):
+        self.sock = socket.create_connection((host, port), timeout=connect_timeout)
+        self.sock.settimeout(None)  # switch to blocking after connect
+        self._buf: bytes = b""
+
+    def close(self) -> None:
+        try:
+            self.sock.close()
+        except Exception:
+            pass
+
+    def readline(self, timeout_s: float | None = None) -> str | None:
+        """Read one newline-delimited line, returning None on timeout or close."""
+        deadline = time.monotonic() + timeout_s if timeout_s is not None else None
+
+        while True:
+            nl = self._buf.find(b"\n")
+            if nl >= 0:
+                line, self._buf = self._buf[:nl], self._buf[nl + 1:]
+                return line.decode("utf-8", errors="replace")
+
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                ready, _, _ = select.select([self.sock], [], [], remaining)
+                if not ready:
+                    return None
+
+            try:
+                chunk = self.sock.recv(65536)
+            except OSError:
+                return None
+
+            if not chunk:
+                return None
+            self._buf += chunk
+
+    def send_rpc(self, method: str, params: list | None = None,
+                 timeout_s: float = 10.0) -> Any:
+        """Send a JSON-RPC request and return the parsed result, or None on error."""
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params if params is not None else [],
+        }
+
+        if os.getenv("ELECTRUM_DEBUG"):
+            print(">>>", json.dumps(payload, indent=2), flush=True)
+
+        self.sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+
+        data = self.readline(timeout_s)
+        if data is None:
+            return None
+
+        if os.getenv("ELECTRUM_DEBUG"):
+            print(f"<<< {method}:", data, flush=True)
+
+        try:
+            resp = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+
+        if isinstance(resp, dict) and resp.get("error") is not None:
+            return None
+        if isinstance(resp, dict) and "result" in resp:
+            return resp["result"]
+        return resp
+
+    def read_notification(self, timeout_s: float) -> dict | None:
+        """
+        Read the next server-pushed notification within timeout_s seconds.
+
+        Skips regular RPC responses (those have a 'result' key) and returns
+        only objects that look like notifications (have 'method', no 'result').
+        Returns None on timeout.
+        """
+        deadline = time.monotonic() + timeout_s
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+
+            data = self.readline(remaining)
+            if data is None:
+                return None
+
+            if os.getenv("ELECTRUM_DEBUG"):
+                print("<<< [notification]:", data, flush=True)
+
+            try:
+                obj = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+
+            if isinstance(obj, dict) and "method" in obj and "result" not in obj:
+                return obj
+
+
+# ─── Fixture ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def conn(electrum_config: dict) -> ElectrumConnection:
+    """
+    Fresh Electrum connection per test, with version handshake.
+    Closes the connection after the test regardless of outcome.
+    """
+    host = electrum_config["host"]
+    port = electrum_config["port"]
+    timeout = electrum_config.get("timeout", TestConfig.DEFAULT_SOCKET_TIMEOUT)
+    protocol = electrum_config.get("protocol", ["1.4", "1.6"])
+
+    try:
+        c = ElectrumConnection(host, port, connect_timeout=timeout)
+    except OSError as exc:
+        pytest.skip(f"Cannot connect to {host}:{port}: {exc}")
+
+    result = c.send_rpc("server.version", [_CLIENT_NAME, protocol], timeout_s=timeout)
+    if result is None:
+        c.close()
+        pytest.skip("server.version handshake failed; server unreachable or not Electrum")
+
+    yield c
+    c.close()
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+def test_headers_notification(conn: ElectrumConnection, electrum_config: dict):
+    """
+    Subscribe to blockchain.headers and wait for a real push notification.
+
+    The test subscribes, optionally triggers an external command (via
+    ELECTRUM_TRIGGER_HEADERS env var) to produce a new block, then waits
+    up to --subscription-timeout seconds for the server to push a header.
+
+    Notification format (Electrum protocol):
+        {'method': 'blockchain.headers.subscribe', 'params': [{'height': int, 'hex': str}]}
+    """
+    sub_timeout = electrum_config.get("subscription_timeout", 60.0)
+
+    initial = conn.send_rpc("blockchain.headers.subscribe", timeout_s=10.0)
+    if initial is None:
+        pytest.skip("blockchain.headers.subscribe returned no response")
+
+    assert isinstance(initial, dict) and "height" in initial, (
+        f"Expected {{'height': int, 'hex': str}} from headers.subscribe, got {initial!r}"
+    )
+
+    cmd = os.getenv("ELECTRUM_TRIGGER_HEADERS")
+    if cmd:
+        subprocess.run(cmd, shell=True, check=False)
+    else:
+        print(
+            f"\n  Waiting up to {sub_timeout:.0f}s for a new block notification "
+            "(set ELECTRUM_TRIGGER_HEADERS to trigger one immediately).",
+            flush=True,
+        )
+
+    notif = conn.read_notification(timeout_s=sub_timeout)
+    if notif is None:
+        pytest.skip(
+            f"No header notification received within {sub_timeout:.0f}s. "
+            "Increase --subscription-timeout or use ELECTRUM_TRIGGER_HEADERS."
+        )
+
+    assert notif.get("method") == "blockchain.headers.subscribe", (
+        f"Unexpected notification method: {notif.get('method')!r}"
+    )
+    params = notif.get("params", [])
+    assert isinstance(params, list) and params, \
+        f"Notification 'params' must be a non-empty list, got {params!r}"
+    payload = params[0]
+    assert isinstance(payload, dict), \
+        f"First element of notification params must be a dict, got {payload!r}"
+    assert "height" in payload, f"Notification payload missing 'height': {payload}"
+    assert "hex" in payload, f"Notification payload missing 'hex': {payload}"
+    assert isinstance(payload["height"], int) and payload["height"] > initial["height"], (
+        f"Notification height {payload['height']} must be greater than "
+        f"subscribe height {initial['height']}"
+    )
+    assert isinstance(payload["hex"], str) and len(payload["hex"]) == 160, (
+        f"Notification 'hex' must be 160-char header, got length {len(payload.get('hex', ''))}"
+    )
+
+
+def test_scripthash_notification(conn: ElectrumConnection, electrum_config: dict):
+    """
+    Subscribe to a scripthash and wait for a status push notification.
+
+    Subscribes to EXAMPLE_SCRIPTHASH, optionally triggers an external command
+    (via ELECTRUM_TRIGGER_SCRIPTHASH) to produce on-chain activity, then waits
+    for the server to push a status update.
+
+    Notification format:
+        {'method': 'blockchain.scripthash.subscribe', 'params': [scripthash, status]}
+    where status is null (reset) or a 64-char hex SHA256 hash.
+
+    Note: the status hash must be in natural byte order (not reversed).
+    See docs/bug-electrum-scripthash-status-byteorder.md.
+    """
+    sub_timeout = electrum_config.get("subscription_timeout", 60.0)
+
+    initial = conn.send_rpc(
+        "blockchain.scripthash.subscribe",
+        [ReferenceData.EXAMPLE_SCRIPTHASH],
+        timeout_s=10.0,
+    )
+    # null = no history; 64-char hex = current status hash
+    assert initial is None or (isinstance(initial, str) and len(initial) == 64), (
+        f"blockchain.scripthash.subscribe must return null or a 64-char status hash, "
+        f"got {initial!r}"
+    )
+
+    cmd = os.getenv("ELECTRUM_TRIGGER_SCRIPTHASH")
+    if cmd:
+        subprocess.run(cmd, shell=True, check=False)
+    else:
+        print(
+            f"\n  Waiting up to {sub_timeout:.0f}s for a scripthash notification "
+            "(set ELECTRUM_TRIGGER_SCRIPTHASH to trigger one immediately).",
+            flush=True,
+        )
+
+    notif = conn.read_notification(timeout_s=sub_timeout)
+    if notif is None:
+        pytest.skip(
+            f"No scripthash notification received within {sub_timeout:.0f}s. "
+            "Increase --subscription-timeout or use ELECTRUM_TRIGGER_SCRIPTHASH."
+        )
+
+    assert notif.get("method") == "blockchain.scripthash.subscribe", (
+        f"Unexpected notification method: {notif.get('method')!r}"
+    )
+    params = notif.get("params", [])
+    assert isinstance(params, list) and len(params) == 2, (
+        f"Scripthash notification must have exactly 2 params [scripthash, status], "
+        f"got {params!r}"
+    )
+    scripthash, status = params
+    assert scripthash == ReferenceData.EXAMPLE_SCRIPTHASH, (
+        f"Notification scripthash mismatch: expected {ReferenceData.EXAMPLE_SCRIPTHASH!r}, "
+        f"got {scripthash!r}"
+    )
+    assert status is None or (isinstance(status, str) and len(status) == 64), (
+        f"Notification status must be null or a 64-char hex hash, got {status!r}"
+    )


### PR DESCRIPTION
Extends the Electrum protocol test suite and adds push-notification tests.

- Replace simple global socket in `test_electrum.py` with a session fixture
  that performs the version handshake and stores the negotiated protocol
  version; add version-conditional assertions (response shape differs across
  v1.0–v1.6); expand test coverage across all major method categories.

- Add `test_electrum_subscriptions.py` for `blockchain.headers.subscribe`
  and `blockchain.scripthash.subscribe`; each test opens its own connection
  and waits up to `--subscription-timeout` seconds for a push notification
  before skipping.

- Add `--electrum-protocol` and `--subscription-timeout` CLI options;
  add session header showing host, port, and offered protocol version.

- Extend README with Electrum protocol version matrix (v1.0–v1.6, 30+
  methods), version-conditional assertion table, and known deviations
  from spec (four intentional xfails).