### PR TITLE
Add new native endpoint: chain status.

### DIFF
--- a/endpoints/test_native.py
+++ b/endpoints/test_native.py
@@ -93,6 +93,19 @@ def test_top(native_config):
         assert height >= 100_000, "Chain height should be at least 100k"
 
 
+def test_status(native_config):
+    """Test /v1/status endpoint - local chain synchronization state."""
+    data = get_json(native_config["base_url"], "status")
+    assert isinstance(data, dict)
+    assert set(data) == {"confirmed", "candidate", "current", "coalesced"}
+    assert isinstance(data["confirmed"], int)
+    assert isinstance(data["candidate"], int)
+    assert isinstance(data["current"], bool)
+    assert isinstance(data["coalesced"], bool)
+    assert data["confirmed"] >= 0
+    assert data["candidate"] >= 0
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # BLOCK ENDPOINTS
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/include/bitcoin/server/interfaces/native.hpp
+++ b/include/bitcoin/server/interfaces/native.hpp
@@ -34,6 +34,7 @@ struct native_methods
 
         method<"top", uint8_t, uint8_t>{ "version", "media" },
         method<"top_subscribe", uint8_t, uint8_t, optional<false>>{ "version", "media", "stop" },
+        method<"status", uint8_t, uint8_t>{ "version", "media" },
 
         method<"block", uint8_t, uint8_t, nullable<system::hash_cptr>, nullable<uint32_t>, optional<true>>{ "version", "media", "hash", "height", "witness" },
         method<"block_header", uint8_t, uint8_t, nullable<system::hash_cptr>, nullable<uint32_t>>{ "version", "media", "hash", "height" },
@@ -82,40 +83,41 @@ struct native_methods
 
     using top = at<1>;
     using top_subscribe = at<2>;
+    using status = at<3>;
 
-    using block = at<3>;
-    using block_header = at<4>;
-    using block_header_context = at<5>;
-    using block_details = at<6>;
-    using block_txs = at<7>;
-    using block_filter = at<8>;
-    using block_filter_hash = at<9>;
-    using block_filter_header = at<10>;
-    using block_tx = at<11>;
-    using block_subscribe = at<12>;
+    using block = at<4>;
+    using block_header = at<5>;
+    using block_header_context = at<6>;
+    using block_details = at<7>;
+    using block_txs = at<8>;
+    using block_filter = at<9>;
+    using block_filter_hash = at<10>;
+    using block_filter_header = at<11>;
+    using block_tx = at<12>;
+    using block_subscribe = at<13>;
 
-    using tx = at<13>;
-    using tx_header = at<14>;
-    using tx_details = at<15>;
-    using tx_subscribe = at<16>;
+    using tx = at<14>;
+    using tx_header = at<15>;
+    using tx_details = at<16>;
+    using tx_subscribe = at<17>;
 
-    using inputs = at<17>;
-    using input = at<18>;
-    using input_script = at<19>;
-    using input_witness = at<20>;
+    using inputs = at<18>;
+    using input = at<19>;
+    using input_script = at<20>;
+    using input_witness = at<21>;
 
-    using outputs = at<21>;
-    using output = at<22>;
-    using output_script = at<23>;
-    using output_spender = at<24>;
-    using output_spenders = at<25>;
-    using output_subscribe = at<26>;
+    using outputs = at<22>;
+    using output = at<23>;
+    using output_script = at<24>;
+    using output_spender = at<25>;
+    using output_spenders = at<26>;
+    using output_subscribe = at<27>;
 
-    using address = at<27>;
-    using address_confirmed = at<28>;
-    using address_unconfirmed = at<29>;
-    using address_balance = at<30>;
-    using address_subscribe = at<31>;
+    using address = at<28>;
+    using address_confirmed = at<29>;
+    using address_unconfirmed = at<30>;
+    using address_balance = at<31>;
+    using address_subscribe = at<32>;
 };
 
 /// ?format=data|text|json (via query string).
@@ -124,6 +126,7 @@ struct native_methods
 /// /v1/configuration {1}
 
 /// /v1/top {1}
+/// /v1/status {1}
 
 /// /v1/block/hash/[bkhash] {1}
 /// /v1/block/height/[height] {1}

--- a/include/bitcoin/server/protocols/protocol_native.hpp
+++ b/include/bitcoin/server/protocols/protocol_native.hpp
@@ -82,6 +82,8 @@ protected:
         uint8_t version, uint8_t media) NOEXCEPT;
     bool handle_get_top_subscribe(const code& ec, interface::top_subscribe,
         uint8_t version, uint8_t media, bool stop) NOEXCEPT;
+    bool handle_get_status(const code& ec, interface::status,
+        uint8_t version, uint8_t media) NOEXCEPT;
 
     bool handle_get_block(const code& ec, interface::block,
         uint8_t version, uint8_t media, std::optional<system::hash_cptr> hash,

--- a/src/parsers/native_target.cpp
+++ b/src/parsers/native_target.cpp
@@ -101,6 +101,10 @@ code native_target(request_t& out, const std::string_view& path) NOEXCEPT
                 return error::invalid_subcomponent;
         }
     }
+    else if (target == "status")
+    {
+        method = "status";
+    }
     else if (target == "address")
     {
         if (segment == segments.size())

--- a/src/protocols/native/protocol_native.cpp
+++ b/src/protocols/native/protocol_native.cpp
@@ -54,6 +54,7 @@ void protocol_native::start() NOEXCEPT
     // Top methods.
     SUBSCRIBE_NATIVE(handle_get_top, _1, _2, _3, _4);
     SUBSCRIBE_NATIVE(handle_get_top_subscribe, _1, _2, _3, _4, _5);
+    SUBSCRIBE_NATIVE(handle_get_status, _1, _2, _3, _4);
 
     // Block methods.
     SUBSCRIBE_NATIVE(handle_get_block, _1, _2, _3, _4, _5, _6, _7);

--- a/src/protocols/native/protocol_native_block.cpp
+++ b/src/protocols/native/protocol_native_block.cpp
@@ -34,6 +34,29 @@ using namespace network::messages::peer;
 BC_PUSH_WARNING(NO_INCOMPLETE_SWITCH)
 BC_PUSH_WARNING(NO_THROW_IN_NOEXCEPT)
 
+bool protocol_native::handle_get_status(const code& ec, interface::status,
+    uint8_t, uint8_t media) NOEXCEPT
+{
+    if (stopped(ec))
+        return false;
+
+    if (media != json)
+    {
+        send_not_acceptable();
+        return true;
+    }
+
+    const auto& query = archive();
+    send_json(boost::json::object
+    {
+        { "confirmed", query.get_top_confirmed() },
+        { "candidate", query.get_top_candidate() },
+        { "current", is_current_chain(true) },
+        { "coalesced", query.is_coalesced() }
+    }, 80);
+    return true;
+}
+
 bool protocol_native::handle_get_top(const code& ec, interface::top,
     uint8_t, uint8_t media) NOEXCEPT
 {

--- a/test/parsers/native_target.cpp
+++ b/test/parsers/native_target.cpp
@@ -140,6 +140,34 @@ BOOST_AUTO_TEST_CASE(parsers__native_target__top_subscribe_extra_segment__extra_
     BOOST_REQUIRE_EQUAL(native_target(out, path), server::error::extra_segment);
 }
 
+// status
+
+BOOST_AUTO_TEST_CASE(parsers__native_target__status_valid__expected)
+{
+    const std::string path = "/v42/status";
+
+    request_t request{};
+    BOOST_REQUIRE(!native_target(request, path));
+    BOOST_REQUIRE_EQUAL(request.method, "status");
+    BOOST_REQUIRE(request.params.has_value());
+
+    const auto& params = request.params.value();
+    BOOST_REQUIRE(std::holds_alternative<object_t>(params));
+
+    const auto& object = std::get<object_t>(request.params.value());
+    BOOST_REQUIRE_EQUAL(object.size(), 1u);
+
+    const auto version = std::get<uint8_t>(object.at("version").value());
+    BOOST_REQUIRE_EQUAL(version, 42u);
+}
+
+BOOST_AUTO_TEST_CASE(parsers__native_target__status_extra_segment__extra_segment)
+{
+    request_t out{};
+    BOOST_REQUIRE_EQUAL(native_target(out, "/v3/status/extra"),
+        server::error::extra_segment);
+}
+
 // block/height
 
 BOOST_AUTO_TEST_CASE(parsers__native_target__block_height_valid__expected)

--- a/test/protocols/native/native_block.cpp
+++ b/test/protocols/native/native_block.cpp
@@ -24,6 +24,67 @@ using namespace boost::beast;
 
 BOOST_FIXTURE_TEST_SUITE(native_tests, native_ten_block_setup_fixture)
 
+// status (http)
+// ----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(native__status__json__expected)
+{
+    for (size_t height = 1; height <= 9; ++height)
+        BOOST_REQUIRE(query_.push_candidate(query_.to_confirmed(height)));
+
+    const auto response = get_json("/v1/status?format=json");
+    BOOST_REQUIRE(response.is_object());
+
+    const auto& status = response.as_object();
+    BOOST_REQUIRE_EQUAL(status.at("confirmed").as_int64(), 9);
+    BOOST_REQUIRE_EQUAL(status.at("candidate").as_int64(), 9);
+    BOOST_REQUIRE(!status.at("current").as_bool());
+    BOOST_REQUIRE(status.at("coalesced").as_bool());
+}
+
+BOOST_AUTO_TEST_CASE(native__status__candidate_ahead__expected)
+{
+    for (size_t height = 1; height <= 9; ++height)
+        BOOST_REQUIRE(query_.push_candidate(query_.to_confirmed(height)));
+
+    BOOST_REQUIRE(query_.set(test::mock_block10,
+        database::context{ 0, 10, 0 }, false, false));
+    BOOST_REQUIRE(query_.push_candidate(
+        query_.to_header(test::mock_block10.hash())));
+
+    const auto status = get_json("/v1/status?format=json").as_object();
+    BOOST_REQUIRE_EQUAL(status.at("confirmed").as_int64(), 9);
+    BOOST_REQUIRE_EQUAL(status.at("candidate").as_int64(), 10);
+    BOOST_REQUIRE(!status.at("current").as_bool());
+    BOOST_REQUIRE(!status.at("coalesced").as_bool());
+}
+
+BOOST_AUTO_TEST_CASE(native__status__text__not_acceptable)
+{
+    const auto status = get_status("/v1/status?format=text");
+    BOOST_REQUIRE_EQUAL(status, http::status::not_acceptable);
+}
+
+// status (websockets)
+// ----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(native__ws_status__json__expected)
+{
+    BOOST_REQUIRE(!ws_upgrade());
+
+    for (size_t height = 1; height <= 9; ++height)
+        BOOST_REQUIRE(query_.push_candidate(query_.to_confirmed(height)));
+
+    const auto response = ws_get_json("/v1/status?format=json");
+    BOOST_REQUIRE(response.is_object());
+
+    const auto& status = response.as_object();
+    BOOST_REQUIRE_EQUAL(status.at("confirmed").as_int64(), 9);
+    BOOST_REQUIRE_EQUAL(status.at("candidate").as_int64(), 9);
+    BOOST_REQUIRE(!status.at("current").as_bool());
+    BOOST_REQUIRE(status.at("coalesced").as_bool());
+}
+
 // top (http)
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Expose /v1/status over HTTP and WebSocket JSON interfaces. Report the confirmed and candidate heights together with the chain currency and coalescence states.(coalesced refers to whether the nodes confirmed and candidate heights are exactly the same).