### PR TITLE
Add peer.enable_not_found option.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -48,6 +48,7 @@ parser::parser(system::chain::selection context,
 
     configured.network.enable_relay = true;
     configured.network.enable_address = true;
+    configured.network.enable_not_found = true;
     configured.network.enable_address_v2 = false;
     configured.network.enable_witness_tx = false;
     configured.network.enable_compact = false;
@@ -653,6 +654,11 @@ options_metadata parser::load_settings() THROWS
         "peer.enable_reject",
         value<bool>(&configured.network.enable_reject),
         "Enable reject messages, defaults to 'false'."
+    )
+    (
+        "peer.enable_not_found",
+        value<bool>(&configured.network.enable_not_found),
+        "Enable not found messages, defaults to 'true'."
     )
     (
         "peer.enable_relay",


### PR DESCRIPTION
Routes `peer.enable_not_found` through config and parse alongside the other optional peer features, and enables it for the server as `enable_relay` and `enable_address` are enabled, so a node replies `notfound` rather than dropping a peer that asks for something it cannot serve.

The library default stays false; this sets the server default.


Depends on https://github.com/libbitcoin/libbitcoin-network/pull/879.
